### PR TITLE
v1.0.1 update

### DIFF
--- a/shadie/reproduction/angio_scripts.py
+++ b/shadie/reproduction/angio_scripts.py
@@ -6,7 +6,7 @@
 # shadie DEFINITIONS
 DEFS_ANGIO_MONO = """
 // model: monecious angiosperm
-// p0 = haploid population
+// p1 = haploid population
 // 1 = gametophyte (1N) tag
 // 2 = gametophyte clones (1N) tag ----------- none in this model
 // 3 = sporophyte (2N) tag
@@ -17,7 +17,7 @@ DEFS_ANGIO_MONO = """
 
 DEFS_ANGIO_DIO = """
 // model: dioecious angiosperm
-// p0 = haploid population
+// p1 = haploid population
 // 1 = gametophyte (1N) tag
 // 2 = gametophyte clones (1N) tag ----------- none in this model
 // 3 = sporophyte (2N) tag
@@ -27,13 +27,13 @@ DEFS_ANGIO_DIO = """
 """
 
 # -------------
-ANGIO_DIO_FITNESS_SCALE = """males = length(p0.individuals[p0.individuals.tagL0 == F]);
-        p0.fitnessScaling = (GAM_POP_SIZE / (p0.individualCount-males));"""
+ANGIO_DIO_FITNESS_SCALE = """males = length(p1.individuals[p1.individuals.tagL0 == F]);
+        p1.fitnessScaling = (GAM_POP_SIZE / (p1.individualCount-males));"""
 
 EGG_FITNESS_AFFECTS_VIABILITY = """
     // determine how many ovules were fertilized, out of the total
-    ind_fitness = p1.cachedFitness(ind.index);
-    max_fitness = max(p1.cachedFitness(NULL));
+    ind_fitness = p2.cachedFitness(ind.index);
+    max_fitness = max(p2.cachedFitness(NULL));
     ind_fitness_scaled = ind_fitness/max_fitness;
     
     meiosis_reps = rbinom(1, SPO_ARCHEGONIA_PER, ind_fitness_scaled);
@@ -46,7 +46,7 @@ POLLEN_COMPETITION = """
     pollen_pool = sample(outcross_sperms, POLLEN_PER_STIGMA);
     for (pollen in pollen_pool) {
         // store fitness value
-        pollen.setValue("fitness", p0.cachedFitness(pollen.index));
+        pollen.setValue("fitness", p1.cachedFitness(pollen.index));
         //pollen.tag = 0; do not remove for now
     }
 
@@ -75,17 +75,17 @@ NO_POLLEN_COMPETITION = """
 """
 
 FIRST1_ANGIO_MONO = """
-    sim.addSubpop('p1', SPO_POP_SIZE);
-    sim.addSubpop('p0', 0);
-    p1.individuals.tag = 3;
+    sim.addSubpop('p2', SPO_POP_SIZE);
+    sim.addSubpop('p1', 0);
+    p2.individuals.tag = 3;
 """
 
 FIRST1_ANGIO_DIO = """
-    sim.addSubpop('p1', SPO_POP_SIZE);
-    sim.addSubpop('p0', 0);
-    p1.individuals.tag = 3;
-    p1.individuals.setValue('maternal_fitness', 1.0);
-    p1.individuals.tagL0 = (runif(p1.individualCount) < SPO_FEMALE_TO_MALE_RATIO);
+    sim.addSubpop('p2', SPO_POP_SIZE);
+    sim.addSubpop('p1', 0);
+    p2.individuals.tag = 3;
+    p2.individuals.setValue('maternal_fitness', 1.0);
+    p2.individuals.tagL0 = (runif(p2.individualCount) < SPO_FEMALE_TO_MALE_RATIO);
 """
 
 
@@ -99,14 +99,14 @@ FIRST1_ANGIO_DIO = """
 # -------------------------
 # TAGS
 # 1, 2, 41, 42
-REPRO_ANGIO_DIO_P1 = """
+REPRO_ANGIO_DIO_P2 = """
     ind = individual;
     
-    // clonal individual get added to the p0 pool for next round.
+    // clonal individual get added to the p1 pool for next round.
     // NOTE: this doesn't allow clones to reproduce this round.
     if (runif(1) < SPO_CLONE_RATE) {{
         for (i in seqLen(SPO_CLONES_PER)) {{
-            child = p1.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL);
+            child = p2.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL);
             child.tag = 4; // sporophyte clone
             child.tagL0 = ind.tagL0;
             
@@ -123,7 +123,7 @@ REPRO_ANGIO_DIO_P1 = """
         //one egg per archegonia (fertilized ovule)
         for (rep in meiosis_reps){{
             breaks = sim.chromosome.drawBreakpoints(individual);
-            egg = p0.addRecombinant(ind.genome1, ind.genome2, breaks, NULL, NULL, NULL);
+            egg = p1.addRecombinant(ind.genome1, ind.genome2, breaks, NULL, NULL, NULL);
             egg.tag = 1;
             egg.tagL0 = T;
         }}
@@ -137,10 +137,10 @@ REPRO_ANGIO_DIO_P1 = """
             breaks2 = sim.chromosome.drawBreakpoints(ind);
         
             // create four meiotic products
-            child1 = p0.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
-            child2 = p0.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
-            child3 = p0.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
-            child4 = p0.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
+            child1 = p1.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
+            child2 = p1.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
+            child3 = p1.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
+            child4 = p1.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
             children = c(child1, child2, child3, child4);
             children.tag = 1;       
             children.tagL0 = F;
@@ -156,16 +156,16 @@ REPRO_ANGIO_DIO_P1 = """
 # -------------------------
 # TAGS
 # 1, 2
-REPRO_ANGIO_DIO_P0 = """
+REPRO_ANGIO_DIO_P1 = """
     //reproduction scripts run only females
     if (individual.tagL0) {{
     
     // get all males that could fertilize an egg of this female
-    males = p0.individuals[p0.individuals.tagL0==F];
+    males = p1.individuals[p1.individuals.tagL0==F];
     
     // Each egg is outcrossed in this model
     {pollen_selection}
-    child = p1.addRecombinant(individual.genome1, NULL, NULL, sperm.genome1, NULL, NULL);
+    child = p2.addRecombinant(individual.genome1, NULL, NULL, sperm.genome1, NULL, NULL);
     child.tag = 3;
     child.tagL0 = ifelse(runif(1) > SPO_FEMALE_TO_MALE_RATIO, T, F);
     }}
@@ -183,14 +183,14 @@ REPRO_ANGIO_DIO_P0 = """
 # TAGS
 # 0, 1, 2, 44, 5, 45
 
-REPRO_ANGIO_MONO_P1 = """
+REPRO_ANGIO_MONO_P2 = """
     ind = individual;
     
-    // clonal individual get added to the p0 pool for next round.
+    // clonal individual get added to the p1 pool for next round.
     // NOTE: this doesn't allow clones to reproduce this round.
     if (runif(1) < SPO_CLONE_RATE) {{
         for (i in seqLen(SPO_CLONES_PER)) {{
-            child = p1.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL);
+            child = p2.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL);
             child.tag = 4; // sporophyte clone
             
             //sporophyte maternal effect not applicable for clones = neutral
@@ -204,7 +204,7 @@ REPRO_ANGIO_MONO_P1 = """
     //one egg per archegonia (fertilized ovule)
     for (rep in meiosis_reps){{
         breaks = sim.chromosome.drawBreakpoints(individual);
-        egg = p0.addRecombinant(ind.genome1, ind.genome2, breaks, NULL, NULL, NULL);
+        egg = p1.addRecombinant(ind.genome1, ind.genome2, breaks, NULL, NULL, NULL);
         egg.tag = 1;
         egg.tagL0 = T;
     }}
@@ -216,10 +216,10 @@ REPRO_ANGIO_MONO_P1 = """
         breaks2 = sim.chromosome.drawBreakpoints(ind);
         
         // create four meiotic products
-        child1 = p0.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
-        child2 = p0.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
-        child3 = p0.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
-        child4 = p0.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
+        child1 = p1.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
+        child2 = p1.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
+        child3 = p1.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
+        child4 = p1.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
         children = c(child1, child2, child3, child4);
         children.tag = 1;       
         children.tagL0 = F;
@@ -235,12 +235,12 @@ REPRO_ANGIO_MONO_P1 = """
 # TAGS
 # 1, 2, 44, 5
 
-REPRO_ANGIO_MONO_P0 = """
+REPRO_ANGIO_MONO_P1 = """
     //reproduction scripts run only females
     if (individual.tagL0) {{
     
     // get all males that could fertilize an egg of this female
-    males = p0.individuals[p0.individuals.tagL0==F];
+    males = p1.individuals[p1.individuals.tagL0==F];
     
     // if selfing is possible then get all sibling males
    if (SPO_SELF_RATE_PER_EGG > 0)
@@ -261,7 +261,7 @@ REPRO_ANGIO_MONO_P0 = """
       if (mode == 2) {{
         if (siblings.size() > 0) {{
             sibling = sample(siblings, 1);
-            child = p1.addRecombinant(individual.genome1, NULL, NULL,
+            child = p2.addRecombinant(individual.genome1, NULL, NULL,
             sibling.genome1, NULL, NULL, parent1 = individual, parent2 = sibling);
             child.tag = 3; //sporophyte tag
                 }}
@@ -270,7 +270,7 @@ REPRO_ANGIO_MONO_P0 = """
         if (mode == 3) {{
             {pollen_selection}
         
-            child = p1.addRecombinant(individual.genome1, NULL, NULL, sperm.genome1, NULL, NULL);
+            child = p2.addRecombinant(individual.genome1, NULL, NULL, sperm.genome1, NULL, NULL);
             child.tag = 3;
         }}
     }}

--- a/shadie/reproduction/angio_scripts.py
+++ b/shadie/reproduction/angio_scripts.py
@@ -7,6 +7,7 @@
 DEFS_ANGIO_MONO = """
 // model: monecious angiosperm
 // p1 = haploid population
+// p2 = diploid population
 // 1 = gametophyte (1N) tag
 // 2 = gametophyte clones (1N) tag ----------- none in this model
 // 3 = sporophyte (2N) tag
@@ -17,7 +18,9 @@ DEFS_ANGIO_MONO = """
 
 DEFS_ANGIO_DIO = """
 // model: dioecious angiosperm
-// p1 = haploid population
+// p0 = pollen
+// p1 = haploid female population
+// p2 = diploid population
 // 1 = gametophyte (1N) tag
 // 2 = gametophyte clones (1N) tag ----------- none in this model
 // 3 = sporophyte (2N) tag
@@ -27,8 +30,26 @@ DEFS_ANGIO_DIO = """
 """
 
 # -------------
-ANGIO_DIO_FITNESS_SCALE = """males = length(p1.individuals[p1.individuals.tagL0 == F]);
-        p1.fitnessScaling = (GAM_POP_SIZE / (p1.individualCount-males));"""
+
+P1_ANGIO_FITNESS_SCALE = """
+    // random death also occurs to implement GAM_CEILING
+    if (p0.individualCount > GAM_CEILING) {
+        to_kill = p0.individualCount-GAM_CEILING;
+        random_death = sample(p0.individuals, to_kill);
+        sim.killIndividuals(p0.individuals[random_death.index]);
+    }
+
+    // fitness affects female gametophyte survival
+    p1.fitnessScaling = GAM_POP_SIZE / p1.individualCount;
+"""
+
+P2_ANGIO_FITNESS_SCALE = """
+    //kill off pollen
+    sim.killIndividuals(p0.individuals);
+
+    // fitness is scaled relative to number of inds in p2
+    p2.fitnessScaling = SPO_POP_SIZE / p2.individualCount;
+"""
 
 EGG_FITNESS_AFFECTS_VIABILITY = """
     // determine how many ovules were fertilized, out of the total
@@ -47,7 +68,6 @@ POLLEN_COMPETITION = """
     for (pollen in pollen_pool) {
         // store fitness value
         pollen.setValue("fitness", p1.cachedFitness(pollen.index));
-        //pollen.tag = 0; do not remove for now
     }
 
     if (length(pollen_pool)>0) {
@@ -70,24 +90,36 @@ POLLEN_COMPETITION = """
 """
 
 NO_POLLEN_COMPETITION = """
-    //no pollen competition
-    sperm = sample(males, 1);
+        //no pollen competition
+        sperm = sample(males, 1);
 """
 
 FIRST1_ANGIO_MONO = """
     sim.addSubpop('p2', SPO_POP_SIZE);
     sim.addSubpop('p1', 0);
+    sim.addSubpop('p0', 0); // pollen
     p2.individuals.tag = 3;
 """
 
 FIRST1_ANGIO_DIO = """
     sim.addSubpop('p2', SPO_POP_SIZE);
-    sim.addSubpop('p1', 0);
+    sim.addSubpop('p1', 0); //eggs
+    sim.addSubpop('p0', 0); // pollen
     p2.individuals.tag = 3;
     p2.individuals.setValue('maternal_fitness', 1.0);
     p2.individuals.tagL0 = (runif(p2.individualCount) < SPO_FEMALE_TO_MALE_RATIO);
 """
 
+
+EARLY_ANGIO_DIO = """
+    // random death also occurs to implement GAM_CEILING
+    if (p0.individualCount > GAM_CEILING) {
+        to_kill = GAM_CEILING - GAM_POP_SIZE;
+        death_chance = to_kill/p0.individualCount;
+        random_death = sample(c(F,T), p0.individualCount, T, c(1-death_chance, death_chance));
+        sim.killIndividuals(p0.individuals[random_death]);
+    }
+"""
 
 # PARAMETERS
 # spo_flowers_per
@@ -121,7 +153,7 @@ REPRO_ANGIO_DIO_P2 = """
     {egg_selection}
     
         //one egg per archegonia (fertilized ovule)
-        for (rep in meiosis_reps){{
+        for (rep in seqLen(meiosis_reps)){{
             breaks = sim.chromosome.drawBreakpoints(individual);
             egg = p1.addRecombinant(ind.genome1, ind.genome2, breaks, NULL, NULL, NULL);
             egg.tag = 1;
@@ -131,16 +163,16 @@ REPRO_ANGIO_DIO_P2 = """
 
     //males will make pollen
     else {{
-        meiosis_reps = floor(SPO_POLLEN_PER/4);
-        for (rep in meiosis_reps){{
+        meiosis_reps = asInteger(floor(SPO_POLLEN_PER/4));
+        for (rep in seqLen(meiosis_reps)){{
             breaks1 = sim.chromosome.drawBreakpoints(ind);
             breaks2 = sim.chromosome.drawBreakpoints(ind);
         
             // create four meiotic products
-            child1 = p1.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
-            child2 = p1.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
-            child3 = p1.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
-            child4 = p1.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
+            child1 = p0.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
+            child2 = p0.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
+            child3 = p0.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
+            child4 = p0.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
             children = c(child1, child2, child3, child4);
             children.tag = 1;       
             children.tagL0 = F;
@@ -161,7 +193,7 @@ REPRO_ANGIO_DIO_P1 = """
     if (individual.tagL0) {{
     
     // get all males that could fertilize an egg of this female
-    males = p1.individuals[p1.individuals.tagL0==F];
+    males = p0.individuals;
     
     // Each egg is outcrossed in this model
     {pollen_selection}
@@ -182,7 +214,6 @@ REPRO_ANGIO_DIO_P1 = """
 # -------------------------
 # TAGS
 # 0, 1, 2, 44, 5, 45
-
 REPRO_ANGIO_MONO_P2 = """
     ind = individual;
     
@@ -202,24 +233,24 @@ REPRO_ANGIO_MONO_P2 = """
     {egg_selection}
     
     //one egg per archegonia (fertilized ovule)
-    for (rep in meiosis_reps){{
+    for (rep in seqLen(meiosis_reps)){{
         breaks = sim.chromosome.drawBreakpoints(individual);
         egg = p1.addRecombinant(ind.genome1, ind.genome2, breaks, NULL, NULL, NULL);
         egg.tag = 1;
         egg.tagL0 = T;
     }}
     
-    meiosis_reps = floor(SPO_POLLEN_PER/4);
-    for (rep in meiosis_reps)
+    meiosis_reps = asInteger(floor(SPO_POLLEN_PER/4));
+    for (rep in seqLen(meiosis_reps))
     {{
         breaks1 = sim.chromosome.drawBreakpoints(ind);
         breaks2 = sim.chromosome.drawBreakpoints(ind);
         
         // create four meiotic products
-        child1 = p1.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
-        child2 = p1.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
-        child3 = p1.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
-        child4 = p1.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
+        child1 = p0.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL);
+        child2 = p0.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL);
+        child3 = p0.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL);
+        child4 = p0.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL);
         children = c(child1, child2, child3, child4);
         children.tag = 1;       
         children.tagL0 = F;
@@ -240,7 +271,7 @@ REPRO_ANGIO_MONO_P1 = """
     if (individual.tagL0) {{
     
     // get all males that could fertilize an egg of this female
-    males = p1.individuals[p1.individuals.tagL0==F];
+    males = p0.individuals[p0.individuals.tagL0==F];
     
     // if selfing is possible then get all sibling males
    if (SPO_SELF_RATE_PER_EGG > 0)
@@ -266,10 +297,8 @@ REPRO_ANGIO_MONO_P1 = """
             child.tag = 3; //sporophyte tag
                 }}
             }}
-        
         if (mode == 3) {{
             {pollen_selection}
-        
             child = p2.addRecombinant(individual.genome1, NULL, NULL, sperm.genome1, NULL, NULL);
             child.tag = 3;
         }}

--- a/shadie/reproduction/angiobase.py
+++ b/shadie/reproduction/angiobase.py
@@ -20,19 +20,19 @@ from shadie.reproduction.scripts import (
     NO_SPO_CLONES,
     GAM_CLONES,
     NO_GAM_CLONES,
-    GAM_MATERNAL_EFFECT_ON_P1,
+    GAM_MATERNAL_EFFECT_ON_P2,
     NO_GAM_MATERNAL_EFFECT,
-    SPO_MATERNAL_EFFECT_ON_P0,
+    SPO_MATERNAL_EFFECT_ON_P1,
     NO_SPO_MATERNAL_EFFECT,
     EARLY,
+    P2_FITNESS_SCALE_DEFAULT,
     P1_FITNESS_SCALE_DEFAULT,
-    P0_FITNESS_SCALE_DEFAULT,
 )
 from shadie.reproduction.angio_scripts import (
+    REPRO_ANGIO_DIO_P2,
     REPRO_ANGIO_DIO_P1,
-    REPRO_ANGIO_DIO_P0,
+    REPRO_ANGIO_MONO_P2,
     REPRO_ANGIO_MONO_P1,
-    REPRO_ANGIO_MONO_P0,
     FIRST1_ANGIO_MONO,
     FIRST1_ANGIO_DIO,
     ANGIO_DIO_FITNESS_SCALE,
@@ -125,6 +125,7 @@ class AngiospermDioecious(AngiospermBase):
         self._add_alternation_of_generations()
         self._write_trees_file()
         self._define_subpopulations()
+        self._add_first_script()
 
         # specific organism functions
         self._set_gametophyte_k()
@@ -140,12 +141,12 @@ class AngiospermDioecious(AngiospermBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.model.metadata['file_in']:
-            self.model._read_from_file(tag_scripts =[ "p1.individuals.tag=0"])
+            self.model._read_from_file(tag_scripts =[ "p2.individuals.tag=0"])
         else:
             self.model.first(
                 time=1,
                 scripts=FIRST1_ANGIO_DIO,
-                comment="define subpops: p1=diploid sporophytes, p0=haploid gametophytes",
+                comment="define subpops: p2=diploid sporophytes, p1=haploid gametophytes",
             )
 
     def _add_early_script(self):
@@ -153,22 +154,22 @@ class AngiospermDioecious(AngiospermBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.fitness_affects_gam_survival:
-            p0_survival_effects = ANGIO_DIO_FITNESS_SCALE
-        else:
-            p0_survival_effects = P0_RANDOM_SURVIVAL
-
-        if self.fitness_affects_spo_survival:
-            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+            p1_survival_effects = ANGIO_DIO_FITNESS_SCALE
         else:
             p1_survival_effects = P1_RANDOM_SURVIVAL
+
+        if self.fitness_affects_spo_survival:
+            p2_survival_effects = P2_FITNESS_SCALE_DEFAULT
+        else:
+            p2_survival_effects = P2_RANDOM_SURVIVAL
         early_script = (
             EARLY.format(
-                p0_survival_effects = p0_survival_effects,
                 p1_survival_effects = p1_survival_effects,
+                p2_survival_effects = p2_survival_effects,
                 gametophyte_clones=NO_GAM_CLONES,
                 gam_maternal_effect=NO_GAM_MATERNAL_EFFECT,
                 sporophyte_clones=SPO_CLONES,
-                spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P0,
+                spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P1,
             )
         )
         self.model.early(
@@ -183,30 +184,30 @@ class AngiospermDioecious(AngiospermBase):
 
         #add fitness determination of sperm success (or not)
         if self.fitness_affects_gam_mating:
-            repro_script_p0 = REPRO_ANGIO_DIO_P0.format(
+            repro_script_p1 = REPRO_ANGIO_DIO_P1.format(
                 pollen_selection=POLLEN_COMPETITION)
         else:
-            repro_script_p0 = REPRO_ANGIO_DIO_P0.format(
+            repro_script_p1 = REPRO_ANGIO_DIO_P1.format(
                 pollen_selection=NO_POLLEN_COMPETITION)
 
         #add fitness determination of spore # (or not)
         if self.fitness_affects_spo_reproduction:
-            repro_script_p1 = REPRO_ANGIO_DIO_P1.format(
+            repro_script_p2 = REPRO_ANGIO_DIO_P2.format(
                 egg_selection = EGG_FITNESS_AFFECTS_VIABILITY)
 
-        else: repro_script_p1 = REPRO_ANGIO_DIO_P1.format(
+        else: repro_script_p2 = REPRO_ANGIO_DIO_P2.format(
                  egg_selection = NO_EGG_FITNESS)
 
         # add reproduction calls
         self.model.repro(
-            population="p0",
-            scripts=repro_script_p0,
+            population="p1",
+            scripts=repro_script_p1,
             idx="s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
-            population="p1",
-            scripts=repro_script_p1,
+            population="p2",
+            scripts=repro_script_p2,
             idx="s1",
             comment="generates gametes from sporophytes"
         )
@@ -241,6 +242,7 @@ class AngiospermMonoecious(AngiospermBase):
         self._add_alternation_of_generations()
         self._write_trees_file()
         self._set_gametophyte_k()
+        self._add_first_script()
 
         # specific organism functions
         self._define_subpopulations()
@@ -256,12 +258,12 @@ class AngiospermMonoecious(AngiospermBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.model.metadata['file_in']:
-            self.model._read_from_file(tag_scripts =[ "p1.individuals.tag=0"])
+            self.model._read_from_file(tag_scripts =[ "p2.individuals.tag=0"])
         else:
             self.model.first(
                 time=1,
                 scripts=FIRST1_ANGIO_MONO,
-                comment="define subpops: p1=diploid sporophytes, p0=haploid gametophytes",
+                comment="define subpops: p2=diploid sporophytes, p1=haploid gametophytes",
             )
 
     def _add_early_script(self):
@@ -270,21 +272,21 @@ class AngiospermMonoecious(AngiospermBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.fitness_affects_gam_survival:
-            p0_survival_effects = P0_FITNESS_SCALE_DEFAULT
-        else:
-            p0_survival_effects = P0_RANDOM_SURVIVAL
-
-        if self.fitness_affects_spo_survival:
             p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
         else:
             p1_survival_effects = P1_RANDOM_SURVIVAL
+
+        if self.fitness_affects_spo_survival:
+            p2_survival_effects = P2_FITNESS_SCALE_DEFAULT
+        else:
+            p2_survival_effects = P2_RANDOM_SURVIVAL
         early_script = (EARLY.format(
-            p0_survival_effects = p0_survival_effects,
             p1_survival_effects = p1_survival_effects,
+            p2_survival_effects = p2_survival_effects,
             gametophyte_clones=NO_GAM_CLONES,
             gam_maternal_effect=NO_GAM_MATERNAL_EFFECT,
             sporophyte_clones=SPO_CLONES,
-            spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P0,
+            spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P1,
             )
         )
 
@@ -300,29 +302,29 @@ class AngiospermMonoecious(AngiospermBase):
         
         #add fitness determination of sperm success (or not)
         if self.fitness_affects_gam_mating:
-            repro_script_p0 = REPRO_ANGIO_MONO_P0.format(
+            repro_script_p1 = REPRO_ANGIO_MONO_P1.format(
                  pollen_selection=POLLEN_COMPETITION)
         else:
-            repro_script_p0 = REPRO_ANGIO_MONO_P0.format(
+            repro_script_p1 = REPRO_ANGIO_MONO_P1.format(
                  pollen_selection=NO_POLLEN_COMPETITION)
 
         #add fitness determination of spore # (or not)
         if self.fitness_affects_spo_reproduction:
-            repro_script_p1 = REPRO_ANGIO_MONO_P1.format(
+            repro_script_p2 = REPRO_ANGIO_MONO_P2.format(
                 egg_selection = EGG_FITNESS_AFFECTS_VIABILITY)
 
-        else: repro_script_p1 = REPRO_ANGIO_MONO_P1.format(
+        else: repro_script_p2 = REPRO_ANGIO_MONO_P2.format(
                 egg_selection = NO_EGG_FITNESS)
 
         self.model.repro(
-            population="p0",
-            scripts=repro_script_p0,
+            population="p1",
+            scripts=repro_script_p1,
             idx="s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
-            population="p1",
-            scripts=repro_script_p1,
+            population="p2",
+            scripts=repro_script_p2,
             idx="s1",
             comment="generates gametes from sporophytes"
         )

--- a/shadie/reproduction/angiobase.py
+++ b/shadie/reproduction/angiobase.py
@@ -16,8 +16,14 @@ from typing import Tuple, Optional, Union
 from dataclasses import dataclass, field
 from shadie.reproduction.base import NonWrightFisher
 from shadie.reproduction.scripts import (
+    SPO_CLONES,
+    NO_SPO_CLONES,
+    GAM_CLONES,
+    NO_GAM_CLONES,
+    GAM_MATERNAL_EFFECT_ON_P1,
+    NO_GAM_MATERNAL_EFFECT,
     SPO_MATERNAL_EFFECT_ON_P0,
-    P0_FITNESS_SCALE_DEFAULT,
+    NO_SPO_MATERNAL_EFFECT,
     EARLY,
     P1_FITNESS_SCALE_DEFAULT,
     P0_FITNESS_SCALE_DEFAULT,
@@ -27,9 +33,15 @@ from shadie.reproduction.angio_scripts import (
     REPRO_ANGIO_DIO_P0,
     REPRO_ANGIO_MONO_P1,
     REPRO_ANGIO_MONO_P0,
-    EARLY1_ANGIO_DIO,
+    FIRST1_ANGIO_MONO,
+    FIRST1_ANGIO_DIO,
     ANGIO_DIO_FITNESS_SCALE,
-    DEFS_ANGIO,
+    DEFS_ANGIO_MONO,
+    DEFS_ANGIO_DIO,
+    POLLEN_COMPETITION,
+    NO_POLLEN_COMPETITION,
+    NO_EGG_FITNESS,
+    EGG_FITNESS_AFFECTS_VIABILITY,
 )
 
 DTYPES = ("d", "dio", "dioecy", "dioecious",)
@@ -53,6 +65,7 @@ class AngiospermBase(NonWrightFisher):
     pollen_success_rate: float
     pollen_competition: str
     stigma_pollen_per: int
+    gam_ceiling: int
     _gens_per_lifecycle: int = field(default=2, init=False)
 
     def __post_init__(self):
@@ -85,6 +98,10 @@ class AngiospermDioecious(AngiospermBase):
     """Superclass of Spermatophyte base with dioecious functions."""
     mode: str = field(default="dioecious", init=False)
     spo_female_to_male_ratio: Tuple[float,float]
+    fitness_affects_spo_survival: bool = True
+    fitness_affects_spo_reproduction: bool = False
+    fitness_affects_gam_survival: bool = True
+    fitness_affects_gam_mating: bool = False
 
     def __post_init__(self):
         """set ratio as a float."""
@@ -107,9 +124,10 @@ class AngiospermDioecious(AngiospermBase):
         # methods inherited from parent NonWrightFisher class
         self._add_alternation_of_generations()
         self._write_trees_file()
+        self._define_subpopulations()
 
         # specific organism functions
-        self._define_subpopulations()
+        self._set_gametophyte_k()
         self._add_mode_scripts()
         self._add_early_script()
 
@@ -124,9 +142,9 @@ class AngiospermDioecious(AngiospermBase):
         if self.model.metadata['file_in']:
             self.model._read_from_file(tag_scripts =[ "p1.individuals.tag=0"])
         else:
-            self.model.early(
+            self.model.first(
                 time=1,
-                scripts=EARLY1_ANGIO_DIO,
+                scripts=FIRST1_ANGIO_DIO,
                 comment="define subpops: p1=diploid sporophytes, p0=haploid gametophytes",
             )
 
@@ -134,14 +152,23 @@ class AngiospermDioecious(AngiospermBase):
         """Defines the early() callbacks for each gen.
         This overrides the NonWrightFisher class function of same name.
         """
+        if self.fitness_affects_gam_survival:
+            p0_survival_effects = ANGIO_DIO_FITNESS_SCALE
+        else:
+            p0_survival_effects = P0_RANDOM_SURVIVAL
+
+        if self.fitness_affects_spo_survival:
+            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+        else:
+            p1_survival_effects = P1_RANDOM_SURVIVAL
         early_script = (
             EARLY.format(
-                p0_fitnessScaling = ANGIO_DIO_FITNESS_SCALE,
-                p1_fitnessScaling = P1_FITNESS_SCALE_DEFAULT,
-                p0activate= self._p0activate_str,
-                p0deactivate= self._p0deactivate_str,
-                p1activate= self._p1activate_str,
-                p1deactivate= self._p1deactivate_str
+                p0_survival_effects = p0_survival_effects,
+                p1_survival_effects = p1_survival_effects,
+                gametophyte_clones=NO_GAM_CLONES,
+                gam_maternal_effect=NO_GAM_MATERNAL_EFFECT,
+                sporophyte_clones=SPO_CLONES,
+                spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P0,
             )
         )
         self.model.early(
@@ -152,19 +179,35 @@ class AngiospermDioecious(AngiospermBase):
 
     def _add_mode_scripts(self):
         """scripts specific to this organism."""
-        #self.model.custom(scripts=FUNCTIONS_ANGIO_MONO, comment = "shadie DEFINITIONS")
+        self.model.custom(scripts=DEFS_ANGIO_DIO, comment = "shadie DEFINITIONS")
+
+        #add fitness determination of sperm success (or not)
+        if self.fitness_affects_gam_mating:
+            repro_script_p0 = REPRO_ANGIO_DIO_P0.format(
+                pollen_selection=POLLEN_COMPETITION)
+        else:
+            repro_script_p0 = REPRO_ANGIO_DIO_P0.format(
+                pollen_selection=NO_POLLEN_COMPETITION)
+
+        #add fitness determination of spore # (or not)
+        if self.fitness_affects_spo_reproduction:
+            repro_script_p1 = REPRO_ANGIO_DIO_P1.format(
+                egg_selection = EGG_FITNESS_AFFECTS_VIABILITY)
+
+        else: repro_script_p1 = REPRO_ANGIO_DIO_P1.format(
+                 egg_selection = NO_EGG_FITNESS)
 
         # add reproduction calls
         self.model.repro(
             population="p0",
-            scripts=REPRO_ANGIO_DIO_P0,
-            idx="s5",
+            scripts=repro_script_p0,
+            idx="s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p1",
-            scripts=REPRO_ANGIO_DIO_P1,
-            idx="s6",
+            scripts=repro_script_p1,
+            idx="s1",
             comment="generates gametes from sporophytes"
         )
 
@@ -175,6 +218,10 @@ class AngiospermMonoecious(AngiospermBase):
     mode: str = field(default="monecious", init=False)
     spo_self_rate_per_egg: float
     spo_self_rate: float
+    fitness_affects_spo_survival: bool = True
+    fitness_affects_spo_reproduction: bool = False
+    fitness_affects_gam_survival: bool = True
+    fitness_affects_gam_mating: bool = False
 
     def __post_init__(self):
         # set pollen competition as string
@@ -193,6 +240,7 @@ class AngiospermMonoecious(AngiospermBase):
         # methods inherited from parent NonWrightFisher class
         self._add_alternation_of_generations()
         self._write_trees_file()
+        self._set_gametophyte_k()
 
         # specific organism functions
         self._define_subpopulations()
@@ -203,19 +251,40 @@ class AngiospermMonoecious(AngiospermBase):
         self._add_initialize_globals()
         self._add_initialize_constants()
 
+    def _define_subpopulations(self):
+        """Defines the subpopulations and males/females.
+        This overrides the NonWrightFisher class function of same name.
+        """
+        if self.model.metadata['file_in']:
+            self.model._read_from_file(tag_scripts =[ "p1.individuals.tag=0"])
+        else:
+            self.model.first(
+                time=1,
+                scripts=FIRST1_ANGIO_MONO,
+                comment="define subpops: p1=diploid sporophytes, p0=haploid gametophytes",
+            )
+
     def _add_early_script(self):
         """
         Defines the early() callbacks for each gen.
         This overrides the NonWrightFisher class function of same name.
         """
-        early_script = (
-            EARLY.format(
-                p0_fitnessScaling=P0_FITNESS_SCALE_DEFAULT,
-                p1_fitnessScaling=P1_FITNESS_SCALE_DEFAULT,
-                p0activate=self._p0activate_str,
-                p0deactivate=self._p0deactivate_str,
-                p1activate=self._p1activate_str,
-                p1deactivate=self._p1deactivate_str
+        if self.fitness_affects_gam_survival:
+            p0_survival_effects = P0_FITNESS_SCALE_DEFAULT
+        else:
+            p0_survival_effects = P0_RANDOM_SURVIVAL
+
+        if self.fitness_affects_spo_survival:
+            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+        else:
+            p1_survival_effects = P1_RANDOM_SURVIVAL
+        early_script = (EARLY.format(
+            p0_survival_effects = p0_survival_effects,
+            p1_survival_effects = p1_survival_effects,
+            gametophyte_clones=NO_GAM_CLONES,
+            gam_maternal_effect=NO_GAM_MATERNAL_EFFECT,
+            sporophyte_clones=SPO_CLONES,
+            spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P0,
             )
         )
 
@@ -227,18 +296,34 @@ class AngiospermMonoecious(AngiospermBase):
 
     def _add_mode_scripts(self):
         """scripts specific to this organism."""
-        # self.model.custom(scripts=FUNCTIONS_ANGIO_MONO, comment = "shadie DEFINITIONS")
+        self.model.custom(scripts=DEFS_ANGIO_MONO, comment = "shadie DEFINITIONS")
+        
+        #add fitness determination of sperm success (or not)
+        if self.fitness_affects_gam_mating:
+            repro_script_p0 = REPRO_ANGIO_MONO_P0.format(
+                 pollen_selection=POLLEN_COMPETITION)
+        else:
+            repro_script_p0 = REPRO_ANGIO_MONO_P0.format(
+                 pollen_selection=NO_POLLEN_COMPETITION)
+
+        #add fitness determination of spore # (or not)
+        if self.fitness_affects_spo_reproduction:
+            repro_script_p1 = REPRO_ANGIO_MONO_P1.format(
+                egg_selection = EGG_FITNESS_AFFECTS_VIABILITY)
+
+        else: repro_script_p1 = REPRO_ANGIO_MONO_P1.format(
+                egg_selection = NO_EGG_FITNESS)
 
         self.model.repro(
             population="p0",
-            scripts=REPRO_ANGIO_MONO_P0,
-            idx="s5",
+            scripts=repro_script_p0,
+            idx="s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p1",
-            scripts=REPRO_ANGIO_MONO_P1,
-            idx="s6",
+            scripts=repro_script_p1,
+            idx="s1",
             comment="generates gametes from sporophytes"
         )
 
@@ -282,9 +367,10 @@ if __name__ == "__main__":
         # init the model
         mod.initialize(chromosome=chrom)
 
-        mod.reproduction.angiosperm_monoecious(
+        mod.reproduction.angiosperm_dioecious(
             spo_pop_size=1000,
             gam_pop_size=1000,
+            spo_female_to_male_ratio = (1,1)
         )
 
     print(mod.script)

--- a/shadie/reproduction/angiobase.py
+++ b/shadie/reproduction/angiobase.py
@@ -35,7 +35,8 @@ from shadie.reproduction.angio_scripts import (
     REPRO_ANGIO_MONO_P1,
     FIRST1_ANGIO_MONO,
     FIRST1_ANGIO_DIO,
-    ANGIO_DIO_FITNESS_SCALE,
+    P1_ANGIO_FITNESS_SCALE,
+    P2_ANGIO_FITNESS_SCALE,
     DEFS_ANGIO_MONO,
     DEFS_ANGIO_DIO,
     POLLEN_COMPETITION,
@@ -154,12 +155,12 @@ class AngiospermDioecious(AngiospermBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.fitness_affects_gam_survival:
-            p1_survival_effects = ANGIO_DIO_FITNESS_SCALE
+            p1_survival_effects = P1_ANGIO_FITNESS_SCALE
         else:
             p1_survival_effects = P1_RANDOM_SURVIVAL
 
         if self.fitness_affects_spo_survival:
-            p2_survival_effects = P2_FITNESS_SCALE_DEFAULT
+            p2_survival_effects = P2_ANGIO_FITNESS_SCALE
         else:
             p2_survival_effects = P2_RANDOM_SURVIVAL
         early_script = (
@@ -202,13 +203,13 @@ class AngiospermDioecious(AngiospermBase):
         self.model.repro(
             population="p1",
             scripts=repro_script_p1,
-            idx="s0",
+            idx="s1",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p2",
             scripts=repro_script_p2,
-            idx="s1",
+            idx="s2",
             comment="generates gametes from sporophytes"
         )
 
@@ -272,12 +273,12 @@ class AngiospermMonoecious(AngiospermBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.fitness_affects_gam_survival:
-            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+            p1_survival_effects = P1_ANGIO_FITNESS_SCALE
         else:
             p1_survival_effects = P1_RANDOM_SURVIVAL
 
         if self.fitness_affects_spo_survival:
-            p2_survival_effects = P2_FITNESS_SCALE_DEFAULT
+            p2_survival_effects = P2_ANGIO_FITNESS_SCALE
         else:
             p2_survival_effects = P2_RANDOM_SURVIVAL
         early_script = (EARLY.format(
@@ -319,13 +320,13 @@ class AngiospermMonoecious(AngiospermBase):
         self.model.repro(
             population="p1",
             scripts=repro_script_p1,
-            idx="s0",
+            idx="s1",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p2",
             scripts=repro_script_p2,
-            idx="s1",
+            idx="s2",
             comment="generates gametes from sporophytes"
         )
 
@@ -369,10 +370,10 @@ if __name__ == "__main__":
         # init the model
         mod.initialize(chromosome=chrom)
 
-        mod.reproduction.angiosperm_dioecious(
+        mod.reproduction.angiosperm_monoecious(
             spo_pop_size=1000,
             gam_pop_size=1000,
-            spo_female_to_male_ratio = (1,1)
+            #spo_female_to_male_ratio = (1,1)
         )
 
     print(mod.script)

--- a/shadie/reproduction/api.py
+++ b/shadie/reproduction/api.py
@@ -48,6 +48,10 @@ class ReproductionApi:
         spo_spores_per: int=100,
         gam_archegonia_per: int=10,
         gam_ceiling: int=None,
+        fitness_affects_spo_survival: bool=True,
+        fitness_affects_spo_reproduction: bool=False,
+        fitness_affects_gam_survival: bool=True,
+        fitness_affects_gam_mating: bool=False,
     ):
         """Adds Monoicous Bryophyte life history to model.
 
@@ -105,6 +109,10 @@ class ReproductionApi:
             spo_spores_per=spo_spores_per,
             gam_archegonia_per=gam_archegonia_per,
             gam_ceiling=gam_ceiling,
+            fitness_affects_spo_survival=fitness_affects_spo_survival,
+            fitness_affects_spo_reproduction=fitness_affects_spo_reproduction,
+            fitness_affects_gam_survival=fitness_affects_gam_survival,
+            fitness_affects_gam_mating=fitness_affects_gam_mating,
         ).run()
 
     def bryophyte_dioicous(
@@ -221,6 +229,10 @@ class ReproductionApi:
         spo_spores_per: int=100,
         gam_archegonia_per = 1,
         gam_ceiling: int =None,
+        fitness_affects_spo_survival: bool=True,
+        fitness_affects_spo_reproduction: bool=False,
+        fitness_affects_gam_survival: bool=True,
+        fitness_affects_gam_mating: bool=False,
     ):
         """
         Generate scripts appropriate for an pteridophyte (lycophytes
@@ -288,6 +300,10 @@ class ReproductionApi:
             spo_spores_per=spo_spores_per,
             gam_archegonia_per=gam_archegonia_per,
             gam_ceiling=gam_ceiling,
+            fitness_affects_spo_survival=fitness_affects_spo_survival,
+            fitness_affects_spo_reproduction=fitness_affects_spo_reproduction,
+            fitness_affects_gam_survival=fitness_affects_gam_survival,
+            fitness_affects_gam_mating=fitness_affects_gam_mating,
         ).run()
 
     def pteridophyte_heterosporous(
@@ -311,6 +327,10 @@ class ReproductionApi:
         # megasporangia_megaspores_per: int=1,
         # microsporangia_microspores_per: int=100,
         gam_ceiling: int =None,
+        fitness_affects_spo_survival: bool=True,
+        fitness_affects_spo_reproduction: bool=False,
+        fitness_affects_gam_survival: bool=True,
+        fitness_affects_gam_mating: bool=False,
     ):
         """
         Generate scripts appropriate for an pteridophyte (lycophytes
@@ -377,6 +397,10 @@ class ReproductionApi:
             # megasporangia_megaspores_per=megasporangia_megaspores_per,
             # microsporangia_microspores_per=microsporangia_microspores_per,
             gam_ceiling=gam_ceiling,
+            fitness_affects_spo_survival=fitness_affects_spo_survival,
+            fitness_affects_spo_reproduction=fitness_affects_spo_reproduction,
+            fitness_affects_gam_survival=fitness_affects_gam_survival,
+            fitness_affects_gam_mating=fitness_affects_gam_mating,
         ).run()
 
     def pteridophyte_vittaria(
@@ -403,6 +427,10 @@ class ReproductionApi:
         gam_ceiling: int =None,
         sex: str="F",
         sex_rate: float=0.0001,
+        fitness_affects_spo_survival: bool=True,
+        fitness_affects_spo_reproduction: bool=False,
+        fitness_affects_gam_survival: bool=True,
+        fitness_affects_gam_mating: bool=False,
         ):
         """
         Generate scripts appropriate for an pteridophyte (lycophytes
@@ -472,6 +500,10 @@ class ReproductionApi:
             gam_ceiling=gam_ceiling,
             sex=sex,
             sex_rate=sex_rate,
+            fitness_affects_spo_survival=fitness_affects_spo_survival,
+            fitness_affects_spo_reproduction=fitness_affects_spo_reproduction,
+            fitness_affects_gam_survival=fitness_affects_gam_survival,
+            fitness_affects_gam_mating=fitness_affects_gam_mating,
         ).run()
 
     def angiosperm_monoecious(
@@ -493,6 +525,11 @@ class ReproductionApi:
         pollen_success_rate: float=1.0,
         pollen_competition: str="F",
         stigma_pollen_per: int=5,
+        gam_ceiling: int=None,
+        fitness_affects_spo_survival: bool=True,
+        fitness_affects_spo_reproduction: bool=False,
+        fitness_affects_gam_survival: bool=True,
+        fitness_affects_gam_mating: bool=False,
     ):
         AngiospermMonoecious(
             model=self.model,
@@ -513,6 +550,11 @@ class ReproductionApi:
             pollen_success_rate=pollen_success_rate,
             pollen_competition=pollen_competition,
             stigma_pollen_per=stigma_pollen_per,
+            gam_ceiling=gam_ceiling,
+            fitness_affects_spo_survival=fitness_affects_spo_survival,
+            fitness_affects_spo_reproduction=fitness_affects_spo_reproduction,
+            fitness_affects_gam_survival=fitness_affects_gam_survival,
+            fitness_affects_gam_mating=fitness_affects_gam_mating,
         ).run()
 
     def angiosperm_dioecious(
@@ -533,6 +575,11 @@ class ReproductionApi:
         pollen_success_rate: float=1.0,
         pollen_competition: str="F",
         stigma_pollen_per: int=5,
+        gam_ceiling: int=None,
+        fitness_affects_spo_survival: bool=True,
+        fitness_affects_spo_reproduction: bool=False,
+        fitness_affects_gam_survival: bool=True,
+        fitness_affects_gam_mating: bool=False,
     ):
         AngiospermDioecious(
             model=self.model,
@@ -552,105 +599,15 @@ class ReproductionApi:
             pollen_success_rate=pollen_success_rate,
             pollen_competition=pollen_competition,
             stigma_pollen_per=stigma_pollen_per,
+            gam_ceiling=gam_ceiling,
+            fitness_affects_spo_survival=fitness_affects_spo_survival,
+            fitness_affects_spo_reproduction=fitness_affects_spo_reproduction,
+            fitness_affects_gam_survival=fitness_affects_gam_survival,
+            fitness_affects_gam_mating=fitness_affects_gam_mating,
         ).run()
+    
     # def gymnosperm_monosporous(...)
     # def gymnosperm_heterosporous(...)
-
-    def spermatophyte(
-        self,
-        spo_pop_size: int,
-        gam_pop_size: int,
-        spo_mutation_rate: Optional[float]=None,
-        gam_mutation_rate: Optional[float]=0.0,
-        spo_female_to_male_ratio: float.as_integer_ratio = (1,1),
-        spo_clone_rate: float=0.0,
-        spo_clones_per: int =1,
-        spo_maternal_effect: float =0.0,
-        spo_random_death_chance: float=0,
-        gam_random_death_chance: float=0,
-        spo_pollen_per: int=100,
-        spo_archegonia_per: int=30,
-        fertilization_rate: float=0.7,
-        pollen_success_rate: float=1.0,
-        pollen_competition: str="F",
-        stigma_pollen_per: int=5,
-        _chromosome=None,
-        _sim_time = None,
-        _file_in = None,
-        _file_out = None,
-    ):
-        """
-        Generate scripts appropriate for an angiosperm (flowering plant)
-        life history. Appropriate for gymnosperms as well.
-        This adds code to the following
-        SLiM script blocks: reproduction, early, ...
-
-        Parameters:
-        -----------
-        mode: str
-            A life history strategy or "dio" or "mono" -ecious.
-        spo_pop_size: int
-            Sporophyte (diploid) effective population size.
-        gam_pop_size: int
-            Gametophyte (haploid) effective population size.
-        spo_mutation_rate: float
-            Sporophyte mutation rate; chance mutations will arise during
-            the sporophyte generation
-        gam_mutation_rate: float
-            Gametophyte mutation rate; chance mutations will arise during
-            the gametophyte generation. Default = 0
-        spo_female_to_male_ratio: tuple
-            Sporophyte female:male ratio; e.g. (1,1)
-        gam_female_to_male_ratio: tuple
-            Gametophyte female:male ratio; e.g. (1,1)
-        spo_clone_rate: float
-            Chance a sporophyte will clone
-        spo_clones_per: int
-            Number of clones produced by each clonal sporophyte
-        ovule_count: int
-            Number of ovules per sporophyte (remmeber to multiply number
-            of flowers on each individual by number of ovules)
-        ovule_fertilization_rate: float
-            chance an ovule will be viable and set seed
-        pollen_succcess_rate: float
-            chance a give pollen will succcessfully fertilize an ovule
-        pollen_count: int
-            number of pollen produced by each sporophyte
-        pollen_comp: str="F" or "T"
-            turn pollen competition on or off
-        pollen_per_ovule: int
-            number of pollen that will compete to fertilize a single
-            ovule *TODO: update code so that they compete for ALL the
-            ovules in a given flower
-        spo_maternal_effect_weight: float
-            Maternal contribution to haploid offspring fitness (as
-            weighted average)
-        spo_random_death_chance:float
-            Random chance a sporophyte will die before reproducing,
-            regardless of fitness.
-        gam_random_death_chance: float
-            Random chance a gametophyte will die before reproducing,
-            regardless of fitness
-        ...
-        """
-        Spermatophyte(
-            model=self.model,spo_pop_size=spo_pop_size, gam_pop_size=gam_pop_size,
-            spo_mutation_rate = spo_mutation_rate,
-            gam_mutation_rate = gam_mutation_rate,
-            spo_female_to_male_ratio = spo_female_to_male_ratio,
-            spo_clone_rate=spo_clone_rate,
-            spo_clones_per = spo_clones_per, ovule_count=ovule_count,
-            ovule_fertilization_rate=ovule_fertilization_rate,
-            pollen_success_rate=pollen_success_rate,
-            pollen_count=pollen_count, pollen_comp=pollen_comp,
-            pollen_per_ovule=pollen_per_ovule,
-            spo_random_death_chance=spo_random_death_chance,
-            gam_random_death_chance=gam_random_death_chance,
-            _chromosome=self.model.chromosome,
-            _sim_time = 2*self.model.sim_time,
-            _file_in=self.model.file_in,
-            _file_out = self.model.file_out,
-        ).run()
 
     def wright_fisher(
         self,

--- a/shadie/reproduction/api.py
+++ b/shadie/reproduction/api.py
@@ -126,6 +126,10 @@ class ReproductionApi:
         spo_spores_per: int=10,
         gam_archegonia_per = 10,
         gam_ceiling=None,
+        fitness_affects_spo_survival: bool=True,
+        fitness_affects_spo_reproduction: bool=False,
+        fitness_affects_gam_survival: bool=True,
+        fitness_affects_gam_mating: bool=False,
     ):
         """Adds Dioicous Bryophyte life history to model.
 
@@ -189,6 +193,10 @@ class ReproductionApi:
             spo_spores_per=spo_spores_per,
             gam_archegonia_per= gam_archegonia_per,
             gam_ceiling=gam_ceiling,
+            fitness_affects_spo_survival=fitness_affects_spo_survival,
+            fitness_affects_spo_reproduction=fitness_affects_spo_reproduction,
+            fitness_affects_gam_survival=fitness_affects_gam_survival,
+            fitness_affects_gam_mating=fitness_affects_gam_mating,
         ).run()
 
     def pteridophyte_homosporous(

--- a/shadie/reproduction/api.py
+++ b/shadie/reproduction/api.py
@@ -773,11 +773,9 @@ class ReproductionApi:
         self,
         spo_pop_size: int,
         gam_pop_size: int,
-        separate_sexes: bool = False,
-        fitness_affects_haploid_reproduction: bool=False,
-        fitness_affects_haploid_survival: bool=True,
-        fitness_affects_diploid_reproduction: bool=False,
-        fitness_affects_diploid_survival: bool=True,
+        separate_sexes: bool = False,        
+        fitness_affects_survival: bool=True,
+        fitness_affects_reproduction: bool=False,
     ):
         """Generate scripts for an altered Wright-Fisher model with
         alternation of generations. Each generation reproduces and
@@ -803,10 +801,8 @@ class ReproductionApi:
             spo_pop_size=spo_pop_size,
             gam_pop_size=gam_pop_size,
             separate_sexes=separate_sexes,
-            fitness_affects_haploid_reproduction=fitness_affects_reproduction,
-            fitness_affects_haploid_survival=fitness_affects_survival,
-            fitness_affects_diploid_reproduction=fitness_affects_reproduction,
-            fitness_affects_diploid_survival=fitness_affects_survival
+            fitness_affects_reproduction=fitness_affects_reproduction,
+            fitness_affects_survival=fitness_affects_survival
         ).run()
 
 

--- a/shadie/reproduction/api.py
+++ b/shadie/reproduction/api.py
@@ -647,8 +647,9 @@ class ReproductionApi:
     def wright_fisher(
         self,
         pop_size: int,
-        selection: str="none",
-        sexes: bool=False,  # mono/hetero terms is more consistent with others...
+        separate_sexes: bool = False,
+        fitness_affects_reproduction: bool=False,
+        fitness_affects_survival: bool=True,
     ):
         """Generate scripts appropriate for basic WF model, set up as a
         SLiM nonWF model
@@ -669,15 +670,17 @@ class ReproductionApi:
         WrightFisher(
             model=self.model,
             pop_size=pop_size,
-            selection = selection,
-            sexes=sexes,
+            separate_sexes=separate_sexes,
+            fitness_affects_reproduction=fitness_affects_reproduction,
+            fitness_affects_survival=fitness_affects_survival
         ).run()
 
     def moran(
         self,
         pop_size: int,
-        selection: str = "none",
-        sexes: bool = False,  # mono/hetero terms is more consistent with others...
+        separate_sexes: bool = False,
+        fitness_affects_reproduction: bool=False,
+        fitness_affects_survival: bool=True,
     ):
         """Generate scripts appropriate for Moran model. This is similar
         to a WF model, but with overlapping generations
@@ -698,15 +701,17 @@ class ReproductionApi:
         Moran(
             model=self.model,
             pop_size=pop_size,
-            selection=selection,
-            sexes=sexes,
+            separate_sexes=separate_sexes,
+            fitness_affects_reproduction=fitness_affects_reproduction,
+            fitness_affects_survival=fitness_affects_survival
         ).run()
 
     def wright_fisher_haploid_sexual(
         self,
         pop_size: int,
-        selection: str = "none",
-        sexes: bool = False,  # mono/hetero terms is more consistent with others...
+        separate_sexes: bool = False,
+        fitness_affects_survival: bool=True,
+        fitness_affects_reproduction: bool=False,
     ):
         """Generate scripts for a clonal Wright-Fisher model. Each
         generation reproduces sexually and experiences fitness effects
@@ -728,15 +733,16 @@ class ReproductionApi:
         HaploidWF(
             model=self.model,
             pop_size=pop_size,
-            selection=selection,
-            sexes=sexes,
+            separate_sexes=separate_sexes,
+            fitness_affects_reproduction=fitness_affects_reproduction,
+            fitness_affects_survival=fitness_affects_survival
         ).run()
 
     def wright_fisher_haploid_clonal(
         self,
         pop_size: int,
-        selection: str="none",
-        sexes: bool=False,  # mono/hetero terms is more consistent with others...
+        fitness_affects_reproduction: bool=False,
+        fitness_affects_survival: bool=True,
     ):
         """
         Generate scripts for a clonal Wright-Fisher model. Each generation
@@ -759,16 +765,19 @@ class ReproductionApi:
         ClonalHaploidWF(
             model=self.model,
             pop_size=pop_size,
-            selection=selection,
-            sexes=sexes,
+            fitness_affects_reproduction=fitness_affects_reproduction,
+            fitness_affects_survival=fitness_affects_survival
         ).run()
 
     def wright_fisher_altgen(
         self,
         spo_pop_size: int,
         gam_pop_size: int,
-        selection: str="none",
-        sexes: bool=False,  # mono/hetero terms is more consistent with others...
+        separate_sexes: bool = False,
+        fitness_affects_haploid_reproduction: bool=False,
+        fitness_affects_haploid_survival: bool=True,
+        fitness_affects_diploid_reproduction: bool=False,
+        fitness_affects_diploid_survival: bool=True,
     ):
         """Generate scripts for an altered Wright-Fisher model with
         alternation of generations. Each generation reproduces and
@@ -793,30 +802,11 @@ class ReproductionApi:
             model=self.model,
             spo_pop_size=spo_pop_size,
             gam_pop_size=gam_pop_size,
-            selection=selection,
-            sexes=sexes,
-        ).run()
-
-    def wright_fisher_haploid(
-        self,
-        pop_size: int,
-        sexes: bool = False,  # mono/hetero terms is more consistent with others...
-    ):
-        """Generate scripts appropriate for basic SLiM nonWF model,
-        set up as a WF model.
-
-        Parameters:
-        -----------
-        pop_size:
-            Size of the population in number of haploids.
-        sexes: bool
-            default = False; individuals are hemraphroditic. If True,
-            individuals will be male and female
-        """
-        ClonalHaploidWF(
-            model=self.model,
-            pop_size=pop_size,
-            sexes=sexes,
+            separate_sexes=separate_sexes,
+            fitness_affects_haploid_reproduction=fitness_affects_reproduction,
+            fitness_affects_haploid_survival=fitness_affects_survival,
+            fitness_affects_diploid_reproduction=fitness_affects_reproduction,
+            fitness_affects_diploid_survival=fitness_affects_survival
         ).run()
 
 

--- a/shadie/reproduction/base.py
+++ b/shadie/reproduction/base.py
@@ -253,8 +253,8 @@ class WrightFisher(ReproductionBase):
     """Reproduction mode based on Wright-Fisher model."""
     pop_size: int
     _gens_per_lifecycle: int = 1  # internal param
-    fitness_affects_survival: bool =True
-    fitness_affects_reproduction: bool =False
+    fitness_affects_survival: bool = True
+    fitness_affects_reproduction: bool = False
     separate_sexes: bool = False
 
     def run(self):
@@ -368,7 +368,8 @@ if __name__ == "__main__":
     # generate a model w/ slim script
     with shadie.Model() as mod:
         mod.initialize(chromosome=chrom, sim_time=1000, )  # file_in="/tmp/test.trees")
-        mod.reproduction.moran(pop_size=1000)
+        mod.reproduction.wright_fisher(pop_size=1000, fitness_affects_reproduction=True,
+            fitness_affects_survival=False)
     print(mod.script)
     #mod.write("/tmp/slim.slim")
     #mod.run(seed=123, binary="/home/deren/miniconda3/envs/shadie/bin/slim")  # /usr/local/bin/slim")

--- a/shadie/reproduction/bryo_scripts.py
+++ b/shadie/reproduction/bryo_scripts.py
@@ -31,24 +31,29 @@ DEFS_BRYO_MONO = """
 
 # Parameters:
 # GAM_FEMALE_TO_MALE_RATIO
+# SPO_SPORES_PER
 # -------------------------
 # TAGS
-# 1M-2M, 2M-3M
-REPRO_BRYO_DIO_P1 = """
-    ind = individual;
+# 
 
-    // fitness-based determination of how many spores are created by this ind
+FITNESS_AFFECTS_SPO_REPRODUCTION = """
+// fitness-based determination of how many spores are created by this ind
     ind_fitness = p1.cachedFitness(ind.index);
     max_fitness = max(p1.cachedFitness(NULL));
     ind_fitness_scaled = ind_fitness/max_fitness;
 
-    // spore_vector = sample(c(0,1), SPO_SPORES_PER, replace = T, weights = c((1-ind_fitness_scaled), ind_fitness_scaled));
-    // spores = sum(spore_vector);
-    // sample spores weighted by fitness
-    spores = rbinom(1, SPO_SPORES_PER, ind_fitness_scaled); // REPLACE ABOVE
+    spores = rbinom(1, SPO_SPORES_PER, ind_fitness_scaled);
+"""
+
+CONSTANT_SPORES = "spores = SPO_SPORES_PER;"
+
+REPRO_BRYO_DIO_P1 = """
+    ind = individual;
+
+    {spore_determination}
 
     // each spore produces its own recombinant breakpoints
-    for (rep in seqLen(spores)) {
+    for (rep in seqLen(spores)) {{
         breaks1 = sim.chromosome.drawBreakpoints(ind);
         breaks2 = sim.chromosome.drawBreakpoints(ind);
 
@@ -63,7 +68,7 @@ REPRO_BRYO_DIO_P1 = """
         children.tag = 1; //gametophyte tag
         children.tagL0 = (runif(4) < GAM_FEMALE_TO_MALE_RATIO);
 
-    }
+    }}
 """
 
 # Parameters:
@@ -76,14 +81,23 @@ REPRO_BRYO_DIO_P1 = """
 # -------------------------
 # TAGS:
 # 2, 3
+
+FITNESS_AFFECTS_GAM_MATING = """
+// fitness-based determination of sperm sampling
+    sperm_fitness_vector = p0.cachedFitness(outcross_sperms.index);
+    sperm = sample(outcross_sperms, 1, weights = sperm_fitness_vector);
+"""
+
+RANDOM_MATING = "sperm = sample(outcross_sperms, 1);"
+
 REPRO_BRYO_DIO_P0 = """
     // assumes archegonia only produce one egg in bryophytes
     eggs = GAM_ARCHEGONIA_PER;
 
     // clonal individual get added to the p0 pool for next round.
     // NOTE: this doesn't allow clones to reproduce this round.
-    if (runif(1) < GAM_CLONE_RATE) {
-        for (i in seqLen(GAM_CLONES_PER)) {
+    if (runif(1) < GAM_CLONE_RATE) {{
+        for (i in seqLen(GAM_CLONES_PER)) {{
             child = p0.addRecombinant(individual.genome1, NULL, NULL,
             NULL, NULL, NULL, parent1 = individual); // only 1 parent recorded
             child.tag = 2; // marked as clone
@@ -91,8 +105,8 @@ REPRO_BRYO_DIO_P0 = """
             // gametophyte maternal effect not applicable for clones = neutral
             if (GAM_MATERNAL_EFFECT > 0)
                 child.setValue("maternal_fitness", NULL);
-        }
-    }
+        }}
+    }}
 
     // the original plant making the clones can still reproduce regardless
     // of whether or not it cloned.
@@ -101,7 +115,7 @@ REPRO_BRYO_DIO_P0 = """
     // clonal sperm. Because of this, sperm is not removed from the mating pool when used.
 
     // Reproduction scripts run only female gametophytes
-    if (individual.tagL0) {
+    if (individual.tagL0) {{
 
         // archegonia only produce one egg in bryophytes
         eggs = GAM_ARCHEGONIA_PER;
@@ -115,7 +129,7 @@ REPRO_BRYO_DIO_P0 = """
             // shared parent count for sibs is > 0 (1 or 2)
             siblings = males[individual.sharedParentCount(males)!=0];
 
-        for (rep in 1:eggs) {
+        for (rep in 1:eggs) {{
 
             // idea: random_chance_of ... here?
             // weighted sampling: each egg gets gam-selfed, spo-selfed, or outcrossed.
@@ -127,19 +141,19 @@ REPRO_BRYO_DIO_P0 = """
                 );
 
             // intra-gametophytic selfed
-            if (mode == 1) {
+            if (mode == 1) {{
                 child = p1.addRecombinant(individual.genome1, NULL, NULL,
                 individual.genome1, NULL, NULL, parent1 = individual, parent2 = individual);
                 child.tag = 3; //sporophyte tag
                 // gametophyte maternal effect on new sporophyte
                 if (GAM_MATERNAL_EFFECT > 0)
                     child.setValue("maternal_fitness", subpop.cachedFitness(individual.index));
-            }
+            }}
 
             // inter-gametophytic selfed individual (same sporo parent)
             // only occurs IF a sibling gametophyte is still alive.
-            else if (mode == 2) {
-                if (siblings.size() > 0) {
+            else if (mode == 2) {{
+                if (siblings.size() > 0) {{
                     sibling = sample(siblings, 1);
                     child = p1.addRecombinant(individual.genome1, NULL, NULL,
                     sibling.genome1, NULL, NULL, parent1 = individual, parent2=sibling);
@@ -147,25 +161,25 @@ REPRO_BRYO_DIO_P0 = """
                     // gametophyte maternal effect on new sporophyte
                     if (GAM_MATERNAL_EFFECT > 0)
                         child.setValue("maternal_fitness", subpop.cachedFitness(individual.index));
-                }
-            }
+                }}
+            }}
             // outcrossing individual samples any other p0, and checks that it is outcrossing
             // only occurs if a non-sib gametophyte is still alive.
 
-            else {
+            else {{
                 outcross_sperms = males[individual.sharedParentCount(males)==0];
-                if (! isNULL(outcross_sperms)) {
-                    sperm = sample(outcross_sperms, 1);
+                if (! isNULL(outcross_sperms)) {{
+                    {sperm_sampling}
                     child = p1.addRecombinant(individual.genome1, NULL, NULL,
                     sperm.genome1, NULL, NULL, parent1 = individual, parent2=sperm);
                     child.tag = 3; //sporophyte tag
                     // gametophyte maternal effect on new sporophyte
                     if (GAM_MATERNAL_EFFECT > 0)
                         child.setValue("maternal_fitness", subpop.cachedFitness(individual.index));
-                }
-            }
-        }
-    }
+                }}
+            }}
+        }}
+    }}
 """
 
 
@@ -174,6 +188,7 @@ REPRO_BRYO_DIO_P0 = """
 # GAM_FEMALE_TO_MALE_RATIO
 # ------------------
 # TAGS
+
 REPRO_BRYO_MONO_P1 = """
     ind = individual;
 
@@ -182,8 +197,6 @@ REPRO_BRYO_MONO_P1 = """
     max_fitness = max(p1.cachedFitness(NULL));
     ind_fitness_scaled = ind_fitness/max_fitness;
 
-    //spore_vector = sample(c(0,1), SPO_SPORES_PER, replace = T, weights = c((1-ind_fitness_scaled), ind_fitness_scaled));
-    //spores = sum(spore_vector);
     spores = rbinom(1, SPO_SPORES_PER, ind_fitness_scaled); // REPLACE ABOVE
 
     // each spore produces its own recombinant breakpoints

--- a/shadie/reproduction/bryo_scripts.py
+++ b/shadie/reproduction/bryo_scripts.py
@@ -7,8 +7,8 @@
 # shadie DEFINITIONS
 DEFS_BRYO_DIO = """
 // model: dioicous bryophyte
-// p0 = haploid population
-// p1 = diploid population
+// p1 = haploid population
+// p2 = diploid population
 // 1 = gametophyte (1N) tag
 // 2 = gametophyte clones (1N) tag
 // 3 = sporophyte (2N) tag
@@ -19,8 +19,8 @@ DEFS_BRYO_DIO = """
 
 DEFS_BRYO_MONO = """
 // model: monoicous bryophyte
-// p0 = haploid population
-// p1 = diploid population
+// p1 = haploid population
+// p2 = diploid population
 // 1 = gametophyte (1N) tag
 // 2 = gametophyte clones (1N) tag
 // 3 = sporophyte (2N) tag
@@ -37,7 +37,7 @@ DEFS_BRYO_MONO = """
 # 
 
 
-REPRO_BRYO_DIO_P1 = """
+REPRO_BRYO_DIO_P2 = """
     ind = individual;
 
     {spore_determination}
@@ -50,10 +50,10 @@ REPRO_BRYO_DIO_P1 = """
         // create four meiotic products. If later two of these mate with each other
         // it is an example of sporophytic selfing. Because we need to be able to match
         // sibling gametes at that time we tag them now with their sporophyte parent's index.
-        child1 = p0.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL, parent1 = ind);
-        child2 = p0.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL, parent1 = ind);
-        child3 = p0.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL, parent1 = ind);
-        child4 = p0.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL, parent1 = ind);
+        child1 = p1.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL, parent1 = ind);
+        child2 = p1.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL, parent1 = ind);
+        child3 = p1.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL, parent1 = ind);
+        child4 = p1.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL, parent1 = ind);
         children = c(child1, child2, child3, child4);
         children.tag = 1; //gametophyte tag
         children.tagL0 = (runif(4) < GAM_FEMALE_TO_MALE_RATIO);
@@ -73,15 +73,15 @@ REPRO_BRYO_DIO_P1 = """
 # 2, 3
 
 
-REPRO_BRYO_DIO_P0 = """
+REPRO_BRYO_DIO_P1 = """
     // assumes archegonia only produce one egg in bryophytes
     eggs = GAM_ARCHEGONIA_PER;
 
-    // clonal individual get added to the p0 pool for next round.
+    // clonal individual get added to the p1 pool for next round.
     // NOTE: this doesn't allow clones to reproduce this round.
     if (runif(1) < GAM_CLONE_RATE) {{
         for (i in seqLen(GAM_CLONES_PER)) {{
-            child = p0.addRecombinant(individual.genome1, NULL, NULL,
+            child = p1.addRecombinant(individual.genome1, NULL, NULL,
             NULL, NULL, NULL, parent1 = individual); // only 1 parent recorded
             child.tag = 2; // marked as clone
             child.tagL0 = individual.tagL0; // inherits parent sex
@@ -105,7 +105,7 @@ REPRO_BRYO_DIO_P0 = """
 
         // In monoicous bryophytes, gametophytes are either hermaphroditic or male,
         // so "males" includes all the hermaphrodites as well as male gametophytes
-        males = p0.individuals[p0.individuals.tagL0==F];
+        males = p1.individuals[p1.individuals.tagL0==F];
 
         // if selfing is possible then get all sibling males
         if (SPO_SELF_RATE_PER_EGG > 0)
@@ -125,7 +125,7 @@ REPRO_BRYO_DIO_P0 = """
 
             // intra-gametophytic selfed
             if (mode == 1) {{
-                child = p1.addRecombinant(individual.genome1, NULL, NULL,
+                child = p2.addRecombinant(individual.genome1, NULL, NULL,
                 individual.genome1, NULL, NULL, parent1 = individual, parent2 = individual);
                 child.tag = 3; //sporophyte tag
                 // gametophyte maternal effect on new sporophyte
@@ -138,7 +138,7 @@ REPRO_BRYO_DIO_P0 = """
             else if (mode == 2) {{
                 if (siblings.size() > 0) {{
                     sibling = sample(siblings, 1);
-                    child = p1.addRecombinant(individual.genome1, NULL, NULL,
+                    child = p2.addRecombinant(individual.genome1, NULL, NULL,
                     sibling.genome1, NULL, NULL, parent1 = individual, parent2=sibling);
                     child.tag = 3; //sporophyte tag
                     // gametophyte maternal effect on new sporophyte
@@ -146,14 +146,14 @@ REPRO_BRYO_DIO_P0 = """
                         child.setValue("maternal_fitness", subpop.cachedFitness(individual.index));
                 }}
             }}
-            // outcrossing individual samples any other p0, and checks that it is outcrossing
+            // outcrossing individual samples any other p1, and checks that it is outcrossing
             // only occurs if a non-sib gametophyte is still alive.
 
             else {{
                 outcross_sperms = males[individual.sharedParentCount(males)==0];
                 if (! isNULL(outcross_sperms)) {{
                     {sperm_sampling}
-                    child = p1.addRecombinant(individual.genome1, NULL, NULL,
+                    child = p2.addRecombinant(individual.genome1, NULL, NULL,
                     sperm.genome1, NULL, NULL, parent1 = individual, parent2=sperm);
                     child.tag = 3; //sporophyte tag
                     // gametophyte maternal effect on new sporophyte
@@ -172,7 +172,7 @@ REPRO_BRYO_DIO_P0 = """
 # ------------------
 # TAGS
 
-REPRO_BRYO_MONO_P1 = """
+REPRO_BRYO_MONO_P2 = """
     ind = individual;
 
     {spore_determination}
@@ -185,10 +185,10 @@ REPRO_BRYO_MONO_P1 = """
         // create four meiotic products. If later two of these mate with each other
         // it is an example of sporophytic selfing. Because we need to be able to match
         // sibling gametes at that time we tag them now with their sporophyte parent's index.
-        child1 = p0.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL, parent1 = ind);
-        child2 = p0.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL, parent1 = ind);
-        child3 = p0.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL, parent1 = ind);
-        child4 = p0.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL, parent1 = ind);
+        child1 = p1.addRecombinant(ind.genome1, ind.genome2, breaks1, NULL, NULL, NULL, parent1 = ind);
+        child2 = p1.addRecombinant(ind.genome2, ind.genome1, breaks1, NULL, NULL, NULL, parent1 = ind);
+        child3 = p1.addRecombinant(ind.genome1, ind.genome2, breaks2, NULL, NULL, NULL, parent1 = ind);
+        child4 = p1.addRecombinant(ind.genome2, ind.genome1, breaks2, NULL, NULL, NULL, parent1 = ind);
         children = c(child1, child2, child3, child4);
         children.tag = 1; //gametophyte tag
         children.tagL0 = (runif(4) < GAM_FEMALE_TO_MALE_RATIO);
@@ -202,17 +202,17 @@ REPRO_BRYO_MONO_P1 = """
 # ------------------
 # TAGS
 # 2, >1M-
-REPRO_BRYO_MONO_P0 = """
+REPRO_BRYO_MONO_P1 = """
     // assumes archegonia only produce one egg in bryophytes
     eggs = GAM_ARCHEGONIA_PER;
 
-    // clonal individual get added to the p0 pool for next round.
+    // clonal individual get added to the p1 pool for next round.
     // NOTE: this doesn't allow clones to reproduce this round.
     if (runif(1) < GAM_CLONE_RATE) {{
         for (i in seqLen(GAM_CLONES_PER)) {{
 
             // only 1 parent recorded
-            child = p0.addRecombinant(
+            child = p1.addRecombinant(
                 individual.genome1, NULL, NULL, NULL, NULL, NULL, parent1=individual);
 
             // marked as clone
@@ -241,7 +241,7 @@ REPRO_BRYO_MONO_P0 = """
 
         // In monoicous bryophytes, gametophytes are either hermaphroditic or male,
         // so "males" includes all the hermaphrodites as well as male gametophytes
-        males = p0.individuals;
+        males = p1.individuals;
 
         // if selfing is possible then get all sibling males
         if (SPO_SELF_RATE_PER_EGG > 0)
@@ -261,7 +261,7 @@ REPRO_BRYO_MONO_P0 = """
 
             // intra-gametophytic selfed
             if (mode == 1) {{
-                child = p1.addRecombinant(individual.genome1, NULL, NULL,
+                child = p2.addRecombinant(individual.genome1, NULL, NULL,
                 individual.genome1, NULL, NULL, parent1 = individual, parent2 = individual);
                 child.tag = 3; //sporophyte tag
                 //gametophyte maternal effect on new sporophyte
@@ -274,7 +274,7 @@ REPRO_BRYO_MONO_P0 = """
             else if (mode == 2) {{
                 if (siblings.size() > 0) {{
                     sibling = sample(siblings, 1);
-                    child = p1.addRecombinant(individual.genome1, NULL, NULL,
+                    child = p2.addRecombinant(individual.genome1, NULL, NULL,
                     sibling.genome1, NULL, NULL, parent1 = individual, parent2 = sibling);
                     child.tag = 3; //sporophyte tag
                     //gametophyte maternal effect on new sporophyte
@@ -282,14 +282,14 @@ REPRO_BRYO_MONO_P0 = """
                         child.setValue("maternal_fitness", subpop.cachedFitness(individual.index));
                 }}
             }}
-            // outcrossing individual samples any other p0, and checks that it is outcrossing
+            // outcrossing individual samples any other p1, and checks that it is outcrossing
             // only occurs if a non-sib gametophyte is still alive.
 
             else {{
                 outcross_sperms = males[individual.sharedParentCount(males)==0];
                 if (! isNULL(outcross_sperms)) {{
                     {sperm_sampling}
-                    child = p1.addRecombinant(individual.genome1, NULL, NULL,
+                    child = p2.addRecombinant(individual.genome1, NULL, NULL,
                     sperm.genome1, NULL, NULL, parent1 = individual, parent2=sperm);
                     child.tag = 3; //sporophyte tag
                     //gametophyte maternal effect on new sporophyte

--- a/shadie/reproduction/bryobase.py
+++ b/shadie/reproduction/bryobase.py
@@ -179,13 +179,13 @@ class BryophyteDioicous(BryophyteBase):
         self.model.repro(
             population="p1",
             scripts=repro_script_p1,
-            idx = "s0",
+            idx = "s1",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p2",
             scripts=repro_script_p2,
-            idx = "s1",
+            idx = "s2",
             comment="generates gametes from sporophytes"
         )
 
@@ -243,13 +243,13 @@ class BryophyteMonoicous(BryophyteBase):
         self.model.repro(
             population="p1",
             scripts=repro_script_p1,
-            idx = "s0",
+            idx = "s1",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p2",
             scripts=repro_script_p2,
-            idx = "s1",
+            idx = "s2",
             comment="generates gametes from sporophytes"
         )
 

--- a/shadie/reproduction/bryobase.py
+++ b/shadie/reproduction/bryobase.py
@@ -28,6 +28,8 @@ from shadie.reproduction.scripts import (
     EARLY,
     P0_FITNESS_SCALE_DEFAULT,
     P1_FITNESS_SCALE_DEFAULT,
+    P0_RANDOM_SURVIVAL,
+    P1_RANDOM_SURVIVAL,
 )
 from shadie.reproduction.bryo_scripts import (
     REPRO_BRYO_DIO_P1,
@@ -36,16 +38,11 @@ from shadie.reproduction.bryo_scripts import (
     REPRO_BRYO_MONO_P0,
     DEFS_BRYO_MONO,
     DEFS_BRYO_DIO,
+    FITNESS_AFFECTS_SPO_REPRODUCTION,
+    CONSTANT_SPORES,
+    FITNESS_AFFECTS_GAM_MATING,
+    RANDOM_MATING,
 )
-# from shadie.reproduction.bryo_scripts2 import (
-#     LATE_BRYO_MONO,
-#     EARLY_BRYO_MONO,
-#     FUNCTIONS_BRYO_MONO,
-#     SURVIVAL_BRYO_MONO,
-#     REPRO_BRYO_MONO_0, 
-#     REPRO_BRYO_MONO_P1,
-# )
-
 
 
 @dataclass
@@ -103,9 +100,19 @@ class BryophyteBase(NonWrightFisher):
         Defines the early() callbacks for each gen.
         This will be overridden by any callbacks of the same name in subclasses
         """
+        if self.fitness_affects_gam_survival:
+            p0_survival_effects = P0_FITNESS_SCALE_DEFAULT
+        else:
+            p0_survival_effects = P0_RANDOM_SURVIVAL
+
+        if self.fitness_affects_spo_survival:
+            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+        else:
+            p1_survival_effects = P1_RANDOM_SURVIVAL
+
         early_script = (EARLY.format(
-            p0_fitnessScaling= P0_FITNESS_SCALE_DEFAULT,
-            p1_fitnessScaling= P1_FITNESS_SCALE_DEFAULT,
+            p0_survival_effects= p0_survival_effects,
+            p1_survival_effects= p1_survival_effects,
             gametophyte_clones=GAM_CLONES,
             gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P1,
             sporophyte_clones=NO_SPO_CLONES,
@@ -124,10 +131,15 @@ class BryophyteBase(NonWrightFisher):
 class BryophyteDioicous(BryophyteBase):
     mode: str = field(default="dioicous", init=False)
     gam_female_to_male_ratio: Tuple[float,float]
+    fitness_affects_spo_survival: bool = True
+    fitness_affects_spo_reproduction: bool = False
+    fitness_affects_gam_survival: bool = True
+    fitness_affects_gam_mating: bool = False
 
     def run(self):
         """Fill self.model.map with SLiM script snippets."""
         # methods inherited from parent Bryophyte class
+        self._print_warning()
         self._set_mutation_rates()
         self._add_shared_mode_scripts()
         self._add_early_script()
@@ -138,8 +150,8 @@ class BryophyteDioicous(BryophyteBase):
         self._add_alternation_of_generations()
         self._set_gametophyte_k()
         self._add_initialize_globals()
-        self._add_initialize_constants()
         self._write_trees_file()
+        self._add_initialize_constants()
 
         # mode-specific functions
         self._add_mode_scripts()
@@ -147,15 +159,33 @@ class BryophyteDioicous(BryophyteBase):
     def _add_mode_scripts(self):
         """Add reproduction scripts unique to heterosporous bryo."""
         self.model.custom(scripts=DEFS_BRYO_DIO, comment = "shadie DEFINITIONS")
+
+
+        #add fitness determination of sperm success (or not)
+        if self.fitness_affects_gam_mating:
+            repro_script_p0 = REPRO_BRYO_DIO_P0.format(
+                sperm_sampling=FITNESS_AFFECTS_GAM_MATING)
+        else:
+            repro_script_p0 = REPRO_BRYO_DIO_P0.format(
+                sperm_sampling=RANDOM_MATING)
+
+        #add fitness determination of spore # (or not)
+        if self.fitness_affects_spo_reproduction:
+            repro_script_p1 = REPRO_BRYO_DIO_P1.format(
+                spore_determination=FITNESS_AFFECTS_SPO_REPRODUCTION)
+
+        else: repro_script_p1 = REPRO_BRYO_DIO_P1.format(
+                spore_determination=CONSTANT_SPORES)
+
         self.model.repro(
             population="p0",
-            scripts=REPRO_BRYO_DIO_P0,
+            scripts=repro_script_p0,
             idx = "s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p1",
-            scripts=REPRO_BRYO_DIO_P1,
+            scripts=repro_script_p1,
             idx = "s1",
             comment="generates gametes from sporophytes"
         )
@@ -234,10 +264,14 @@ if __name__ == "__main__":
 
     with shadie.Model() as mod:
         mod.initialize(chromosome=chrom, sim_time=50, file_out="/tmp/test.trees")
-        mod.reproduction.bryophyte_monoicous(
+        mod.reproduction.bryophyte_dioicous(
             spo_pop_size=100,
             gam_pop_size=100,
-            gam_self_rate_per_egg=0.8,
+            fitness_affects_gam_mating = True,
+            fitness_affects_gam_survival = True,
+            fitness_affects_spo_survival = False,
+            fitness_affects_spo_reproduction = True,
+            #gam_self_rate_per_egg=0.8,
         )
     print(mod.script)
     # mod.write("/tmp/slim.slim")

--- a/shadie/reproduction/bryobase.py
+++ b/shadie/reproduction/bryobase.py
@@ -20,26 +20,26 @@ from shadie.reproduction.scripts import (
     NO_SPO_CLONES,
     GAM_CLONES,
     NO_GAM_CLONES,
-    GAM_MATERNAL_EFFECT_ON_P1,
+    GAM_MATERNAL_EFFECT_ON_P2,
     NO_GAM_MATERNAL_EFFECT,
-    SPO_MATERNAL_EFFECT_ON_P0,
+    SPO_MATERNAL_EFFECT_ON_P1,
     NO_SPO_MATERNAL_EFFECT,
-    P0_FITNESS_SCALE_DEFAULT,
-    EARLY,
-    P0_FITNESS_SCALE_DEFAULT,
     P1_FITNESS_SCALE_DEFAULT,
-    P0_RANDOM_SURVIVAL,
+    EARLY,
+    P1_FITNESS_SCALE_DEFAULT,
+    P2_FITNESS_SCALE_DEFAULT,
     P1_RANDOM_SURVIVAL,
+    P2_RANDOM_SURVIVAL,
     FITNESS_AFFECTS_SPO_REPRODUCTION,
     CONSTANT_SPORES,
     FITNESS_AFFECTS_GAM_MATING,
     RANDOM_MATING,
 )
 from shadie.reproduction.bryo_scripts import (
+    REPRO_BRYO_DIO_P2,
     REPRO_BRYO_DIO_P1,
-    REPRO_BRYO_DIO_P0,
+    REPRO_BRYO_MONO_P2,
     REPRO_BRYO_MONO_P1,
-    REPRO_BRYO_MONO_P0,
     DEFS_BRYO_MONO,
     DEFS_BRYO_DIO,
 )
@@ -101,20 +101,20 @@ class BryophyteBase(NonWrightFisher):
         This will be overridden by any callbacks of the same name in subclasses
         """
         if self.fitness_affects_gam_survival:
-            p0_survival_effects = P0_FITNESS_SCALE_DEFAULT
-        else:
-            p0_survival_effects = P0_RANDOM_SURVIVAL
-
-        if self.fitness_affects_spo_survival:
             p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
         else:
             p1_survival_effects = P1_RANDOM_SURVIVAL
 
+        if self.fitness_affects_spo_survival:
+            p2_survival_effects = P2_FITNESS_SCALE_DEFAULT
+        else:
+            p2_survival_effects = P2_RANDOM_SURVIVAL
+
         early_script = (EARLY.format(
-            p0_survival_effects= p0_survival_effects,
             p1_survival_effects= p1_survival_effects,
+            p2_survival_effects= p2_survival_effects,
             gametophyte_clones=GAM_CLONES,
-            gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P1,
+            gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P2,
             sporophyte_clones=NO_SPO_CLONES,
             spo_maternal_effect=NO_SPO_MATERNAL_EFFECT,
             )
@@ -162,29 +162,29 @@ class BryophyteDioicous(BryophyteBase):
 
         #add fitness determination of sperm success (or not)
         if self.fitness_affects_gam_mating:
-            repro_script_p0 = REPRO_BRYO_DIO_P0.format(
+            repro_script_p1 = REPRO_BRYO_DIO_P1.format(
                 sperm_sampling=FITNESS_AFFECTS_GAM_MATING)
         else:
-            repro_script_p0 = REPRO_BRYO_DIO_P0.format(
+            repro_script_p1 = REPRO_BRYO_DIO_P1.format(
                 sperm_sampling=RANDOM_MATING)
 
         #add fitness determination of spore # (or not)
         if self.fitness_affects_spo_reproduction:
-            repro_script_p1 = REPRO_BRYO_DIO_P1.format(
+            repro_script_p2 = REPRO_BRYO_DIO_P2.format(
                 spore_determination=FITNESS_AFFECTS_SPO_REPRODUCTION)
 
-        else: repro_script_p1 = REPRO_BRYO_DIO_P1.format(
+        else: repro_script_p2 = REPRO_BRYO_DIO_P2.format(
                 spore_determination=CONSTANT_SPORES)
 
         self.model.repro(
-            population="p0",
-            scripts=repro_script_p0,
+            population="p1",
+            scripts=repro_script_p1,
             idx = "s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
-            population="p1",
-            scripts=repro_script_p1,
+            population="p2",
+            scripts=repro_script_p2,
             idx = "s1",
             comment="generates gametes from sporophytes"
         )
@@ -226,29 +226,29 @@ class BryophyteMonoicous(BryophyteBase):
         
         #add fitness determination of sperm success (or not)
         if self.fitness_affects_gam_mating:
-            repro_script_p0 = REPRO_BRYO_MONO_P0.format(
+            repro_script_p1 = REPRO_BRYO_MONO_P1.format(
                 sperm_sampling=FITNESS_AFFECTS_GAM_MATING)
         else:
-            repro_script_p0 = REPRO_BRYO_MONO_P0.format(
+            repro_script_p1 = REPRO_BRYO_MONO_P1.format(
                 sperm_sampling=RANDOM_MATING)
 
         #add fitness determination of spore # (or not)
         if self.fitness_affects_spo_reproduction:
-            repro_script_p1 = REPRO_BRYO_MONO_P1.format(
+            repro_script_p2 = REPRO_BRYO_MONO_P2.format(
                 spore_determination=FITNESS_AFFECTS_SPO_REPRODUCTION)
 
-        else: repro_script_p1 = REPRO_BRYO_MONO_P1.format(
+        else: repro_script_p2 = REPRO_BRYO_MONO_P2.format(
                 spore_determination=CONSTANT_SPORES)
 
         self.model.repro(
-            population="p0",
-            scripts=repro_script_p0,
+            population="p1",
+            scripts=repro_script_p1,
             idx = "s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
-            population="p1",
-            scripts=repro_script_p1,
+            population="p2",
+            scripts=repro_script_p2,
             idx = "s1",
             comment="generates gametes from sporophytes"
         )

--- a/shadie/reproduction/fernbase.py
+++ b/shadie/reproduction/fernbase.py
@@ -16,15 +16,15 @@ from dataclasses import dataclass, field
 from shadie.reproduction.base import NonWrightFisher
 from shadie.reproduction.scripts import (
     EARLY,
-    P0_FITNESS_SCALE_DEFAULT,
     P1_FITNESS_SCALE_DEFAULT,
+    P2_FITNESS_SCALE_DEFAULT,
     SPO_CLONES,
     NO_SPO_CLONES,
-    SPO_MATERNAL_EFFECT_ON_P0,
+    SPO_MATERNAL_EFFECT_ON_P1,
     NO_SPO_MATERNAL_EFFECT,
     GAM_CLONES,
     NO_GAM_CLONES,
-    GAM_MATERNAL_EFFECT_ON_P1,
+    GAM_MATERNAL_EFFECT_ON_P2,
     NO_GAM_MATERNAL_EFFECT,
     FITNESS_AFFECTS_SPO_REPRODUCTION,
     CONSTANT_SPORES,
@@ -32,18 +32,18 @@ from shadie.reproduction.scripts import (
     RANDOM_MATING,
 )
 from shadie.reproduction.fern_scripts import (
+    REPRO_PTER_HOMOSPORE_P2,
     REPRO_PTER_HOMOSPORE_P1,
-    REPRO_PTER_HOMOSPORE_P0,
+    REPRO_PTER_HETEROSPORE_P2,
     REPRO_PTER_HETEROSPORE_P1,
-    REPRO_PTER_HETEROSPORE_P0,
     PTER_FITNESS_SCALE,
     DEFS_PTER_HOMOSPORE,
     DEFS_PTER_HETEROSPORE,
 )
 
 from shadie.reproduction.vittaria_scripts import (
-    REPRO_PTER_VITTARIA_P0,
     REPRO_PTER_VITTARIA_P1,
+    REPRO_PTER_VITTARIA_P2,
     DEFS_PTER_VITTARIA,
     )
 
@@ -140,23 +140,23 @@ class PteridophyteHomosporous(PteridophyteBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.fitness_affects_gam_survival:
-            p0_survival_effects = P0_FITNESS_SCALE_DEFAULT
-        else:
-            p0_survival_effects = P0_RANDOM_SURVIVAL
-
-        if self.fitness_affects_spo_survival:
             p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
         else:
             p1_survival_effects = P1_RANDOM_SURVIVAL
 
+        if self.fitness_affects_spo_survival:
+            p2_survival_effects = P2_FITNESS_SCALE_DEFAULT
+        else:
+            p2_survival_effects = P2_RANDOM_SURVIVAL
+
         early_script = (EARLY.format(
             # TODO: do not use camelcase for argument
-            p0_survival_effects=p0_survival_effects,
             p1_survival_effects=p1_survival_effects,
+            p2_survival_effects=p2_survival_effects,
             gametophyte_clones=GAM_CLONES,
-            gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P1,
+            gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P2,
             sporophyte_clones=SPO_CLONES,
-            spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P0,
+            spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P1,
             )
         )
 
@@ -172,29 +172,29 @@ class PteridophyteHomosporous(PteridophyteBase):
         
         #add fitness determination of sperm success (or not)
         if self.fitness_affects_gam_mating:
-            repro_script_p0 = REPRO_PTER_HOMOSPORE_P0.format(
+            repro_script_p1 = REPRO_PTER_HOMOSPORE_P1.format(
                 sperm_sampling=FITNESS_AFFECTS_GAM_MATING)
         else:
-            repro_script_p0 = REPRO_PTER_HOMOSPORE_P0.format(
+            repro_script_p1 = REPRO_PTER_HOMOSPORE_P1.format(
                 sperm_sampling=RANDOM_MATING)
 
         #add fitness determination of spore # (or not)
         if self.fitness_affects_spo_reproduction:
-            repro_script_p1 = REPRO_PTER_HOMOSPORE_P1.format(
+            repro_script_p2 = REPRO_PTER_HOMOSPORE_P2.format(
                 spore_determination=FITNESS_AFFECTS_SPO_REPRODUCTION)
 
-        else: repro_script_p1 = REPRO_PTER_HOMOSPORE_P1.format(
+        else: repro_script_p2 = REPRO_PTER_HOMOSPORE_P2.format(
                 spore_determination=CONSTANT_SPORES)
 
         self.model.repro(
-            population="p0",
-            scripts=repro_script_p0,
+            population="p1",
+            scripts=repro_script_p1,
             idx = "s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
-            population="p1",
-            scripts=repro_script_p1,
+            population="p2",
+            scripts=repro_script_p2,
             idx = "s1",
             comment="generates gametes from sporophytes"
         )
@@ -230,23 +230,23 @@ class PteridophyteHeterosporous(PteridophyteBase):
         This overrides the NonWrightFisher class function of same name.
         """
         if self.fitness_affects_gam_survival:
-            p0_survival_effects = PTER_FITNESS_SCALE
-        else:
-            p0_survival_effects = P0_RANDOM_SURVIVAL
-
-        if self.fitness_affects_spo_survival:
-            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+            p1_survival_effects = PTER_FITNESS_SCALE
         else:
             p1_survival_effects = P1_RANDOM_SURVIVAL
 
+        if self.fitness_affects_spo_survival:
+            p2_survival_effects = P2_FITNESS_SCALE_DEFAULT
+        else:
+            p2_survival_effects = P2_RANDOM_SURVIVAL
+
         early_script = (
             EARLY.format(
-                p0_survival_effects=p0_survival_effects,
                 p1_survival_effects=p1_survival_effects,
+                p2_survival_effects=p2_survival_effects,
                 gametophyte_clones=NO_GAM_CLONES,
                 gam_maternal_effect=NO_GAM_MATERNAL_EFFECT,
                 sporophyte_clones=SPO_CLONES,
-                spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P0,
+                spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P1,
             )
         )
 
@@ -262,29 +262,29 @@ class PteridophyteHeterosporous(PteridophyteBase):
 
         #add fitness determination of sperm success (or not)
         if self.fitness_affects_gam_mating:
-            repro_script_p0 = REPRO_PTER_HETEROSPORE_P0.format(
+            repro_script_p1 = REPRO_PTER_HETEROSPORE_P1.format(
                 sperm_sampling=FITNESS_AFFECTS_GAM_MATING)
         else:
-            repro_script_p0 = REPRO_PTER_HETEROSPORE_P0.format(
+            repro_script_p1 = REPRO_PTER_HETEROSPORE_P1.format(
                 sperm_sampling=RANDOM_MATING)
 
         #add fitness determination of spore # (or not)
         if self.fitness_affects_spo_reproduction:
-            repro_script_p1 = REPRO_PTER_HETEROSPORE_P1.format(
+            repro_script_p2 = REPRO_PTER_HETEROSPORE_P2.format(
                 spore_determination=FITNESS_AFFECTS_SPO_REPRODUCTION)
 
-        else: repro_script_p1 = REPRO_PTER_HETEROSPORE_P1.format(
+        else: repro_script_p2 = REPRO_PTER_HETEROSPORE_P2.format(
                 spore_determination=CONSTANT_SPORES)
 
         self.model.repro(
-            population="p0",
-            scripts=repro_script_p0,
+            population="p1",
+            scripts=repro_script_p1,
             idx = "s0",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
-            population="p1",
-            scripts=repro_script_p1,
+            population="p2",
+            scripts=repro_script_p2,
             idx = "s1",
             comment="generates gametes from sporophytes"
         )
@@ -328,12 +328,12 @@ class PteridophyteVittaria(PteridophyteBase):
 
         early_script = (
             EARLY.format(
-                p0_survival_effects= P0_FITNESS_SCALE_DEFAULT,
-                p1_survival_effects= P1_FITNESS_SCALE_DEFAULT,
+                p1_survival_effects= p1_FITNESS_SCALE_DEFAULT,
+                p2_survival_effects= P2_FITNESS_SCALE_DEFAULT,
                 gametophyte_clones=GAM_CLONES,
-                gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P1,
+                gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P2,
                 sporophyte_clones=SPO_CLONES,
-                spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P0,
+                spo_maternal_effect=SPO_MATERNAL_EFFECT_ON_P1,
             )
         )
         self.model.early(
@@ -346,15 +346,15 @@ class PteridophyteVittaria(PteridophyteBase):
 
         self.model.custom(scripts=DEFS_PTER_VITTARIA, comment="shadie DEFINITIONS")
         self.model.repro(
-            population="p0",
+            population="p1",
             idx="s0",
-            scripts=REPRO_PTER_VITTARIA_P0,
+            scripts=REPRO_PTER_VITTARIA_P1,
             comment="generates gametes from gametophytes"
         )
         self.model.repro(
-            population="p1",
+            population="p2",
             idx="s1",
-            scripts=REPRO_PTER_VITTARIA_P1,
+            scripts=REPRO_PTER_VITTARIA_P2,
             comment="generates spores from sporophytes"
         )
 

--- a/shadie/reproduction/fernbase.py
+++ b/shadie/reproduction/fernbase.py
@@ -25,7 +25,11 @@ from shadie.reproduction.scripts import (
     GAM_CLONES,
     NO_GAM_CLONES,
     GAM_MATERNAL_EFFECT_ON_P1,
-    NO_GAM_MATERNAL_EFFECT
+    NO_GAM_MATERNAL_EFFECT,
+    FITNESS_AFFECTS_SPO_REPRODUCTION,
+    CONSTANT_SPORES,
+    FITNESS_AFFECTS_GAM_MATING,
+    RANDOM_MATING,
 )
 from shadie.reproduction.fern_scripts import (
     REPRO_PTER_HOMOSPORE_P1,
@@ -98,13 +102,6 @@ class PteridophyteBase(NonWrightFisher):
             self.spo_mutation_rate = 0.5 * self.model.metadata['mutation_rate']
             self.gam_mutation_rate = 0.5 * self.model.metadata['mutation_rate']
 
-    def _add_shared_mode_scripts(self):
-        """Adds scripts shared by homosp and heterosp superclasses.
-
-        Adds shadie-defined functions
-        """
-
-
 @dataclass
 class PteridophyteHomosporous(PteridophyteBase):
     """Reproduction mode based on homosporoous ferns and lycophytes"""
@@ -114,12 +111,15 @@ class PteridophyteHomosporous(PteridophyteBase):
     gam_maternal_effect: float
     gam_clone_rate: float
     gam_clones_per: int
+    fitness_affects_spo_survival: bool = True
+    fitness_affects_spo_reproduction: bool = False
+    fitness_affects_gam_survival: bool = True
+    fitness_affects_gam_mating: bool = False
 
     def run(self):
         """Fill self.model.map with SLiM script snippets."""
         # methods inherited from parent Pteridophyte class
         self._set_mutation_rates()
-        self._add_shared_mode_scripts()
 
         # methods inherited from parent NonWrightFisher class
         self._add_first_script()
@@ -139,10 +139,20 @@ class PteridophyteHomosporous(PteridophyteBase):
         Defines the early() callbacks for each gen.
         This overrides the NonWrightFisher class function of same name.
         """
+        if self.fitness_affects_gam_survival:
+            p0_survival_effects = P0_FITNESS_SCALE_DEFAULT
+        else:
+            p0_survival_effects = P0_RANDOM_SURVIVAL
+
+        if self.fitness_affects_spo_survival:
+            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+        else:
+            p1_survival_effects = P1_RANDOM_SURVIVAL
+
         early_script = (EARLY.format(
             # TODO: do not use camelcase for argument
-            p0_fitnessScaling=P0_FITNESS_SCALE_DEFAULT,
-            p1_fitnessScaling=P1_FITNESS_SCALE_DEFAULT,
+            p0_survival_effects=p0_survival_effects,
+            p1_survival_effects=p1_survival_effects,
             gametophyte_clones=GAM_CLONES,
             gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P1,
             sporophyte_clones=SPO_CLONES,
@@ -159,29 +169,48 @@ class PteridophyteHomosporous(PteridophyteBase):
     def _add_mode_scripts(self):
         """Add reproduction scripts unique to homosporous pteridophyte."""
         self.model.custom(scripts=DEFS_PTER_HOMOSPORE, comment="shadie DEFINITIONS")
-        self.model.repro(
-            idx="s0",
-            population="p0",
-            scripts=REPRO_PTER_HOMOSPORE_P0,
-            comment="generates gametes from sporophytes"
-        )
-        self.model.repro(
-            idx="s1",
-            population="p1",
-            scripts=REPRO_PTER_HOMOSPORE_P1,
-            comment="generates gametes from sporophytes"
-        )
+        
+        #add fitness determination of sperm success (or not)
+        if self.fitness_affects_gam_mating:
+            repro_script_p0 = REPRO_PTER_HOMOSPORE_P0.format(
+                sperm_sampling=FITNESS_AFFECTS_GAM_MATING)
+        else:
+            repro_script_p0 = REPRO_PTER_HOMOSPORE_P0.format(
+                sperm_sampling=RANDOM_MATING)
 
+        #add fitness determination of spore # (or not)
+        if self.fitness_affects_spo_reproduction:
+            repro_script_p1 = REPRO_PTER_HOMOSPORE_P1.format(
+                spore_determination=FITNESS_AFFECTS_SPO_REPRODUCTION)
+
+        else: repro_script_p1 = REPRO_PTER_HOMOSPORE_P1.format(
+                spore_determination=CONSTANT_SPORES)
+
+        self.model.repro(
+            population="p0",
+            scripts=repro_script_p0,
+            idx = "s0",
+            comment="generates sporophytes from gametes"
+        )
+        self.model.repro(
+            population="p1",
+            scripts=repro_script_p1,
+            idx = "s1",
+            comment="generates gametes from sporophytes"
+        )
 
 @dataclass
 class PteridophyteHeterosporous(PteridophyteBase):
     mode: str = field(default="heterosporous", init=False)
+    fitness_affects_spo_survival: bool = True
+    fitness_affects_spo_reproduction: bool = False
+    fitness_affects_gam_survival: bool = True
+    fitness_affects_gam_mating: bool = False
 
     def run(self):
         """Fill self.model.map with SLiM script snippets."""
         # methods inherited from parent Bryophyte class
         self._set_mutation_rates()
-        self._add_shared_mode_scripts()
 
         # methods inherited from parent NonWrightFisher class
         self._define_subpopulations()
@@ -200,10 +229,20 @@ class PteridophyteHeterosporous(PteridophyteBase):
         Defines the early() callbacks for each gen.
         This overrides the NonWrightFisher class function of same name.
         """
+        if self.fitness_affects_gam_survival:
+            p0_survival_effects = PTER_FITNESS_SCALE
+        else:
+            p0_survival_effects = P0_RANDOM_SURVIVAL
+
+        if self.fitness_affects_spo_survival:
+            p1_survival_effects = P1_FITNESS_SCALE_DEFAULT
+        else:
+            p1_survival_effects = P1_RANDOM_SURVIVAL
+
         early_script = (
             EARLY.format(
-                p0_fitnessScaling=PTER_FITNESS_SCALE,
-                p1_fitnessScaling=P1_FITNESS_SCALE_DEFAULT,
+                p0_survival_effects=p0_survival_effects,
+                p1_survival_effects=p1_survival_effects,
                 gametophyte_clones=NO_GAM_CLONES,
                 gam_maternal_effect=NO_GAM_MATERNAL_EFFECT,
                 sporophyte_clones=SPO_CLONES,
@@ -220,16 +259,33 @@ class PteridophyteHeterosporous(PteridophyteBase):
     def _add_mode_scripts(self):
         """Add reproduction scripts unique to heterosporous bryo."""
         self.model.custom(scripts=DEFS_PTER_HETEROSPORE, comment="shadie DEFINITIONS")
+
+        #add fitness determination of sperm success (or not)
+        if self.fitness_affects_gam_mating:
+            repro_script_p0 = REPRO_PTER_HETEROSPORE_P0.format(
+                sperm_sampling=FITNESS_AFFECTS_GAM_MATING)
+        else:
+            repro_script_p0 = REPRO_PTER_HETEROSPORE_P0.format(
+                sperm_sampling=RANDOM_MATING)
+
+        #add fitness determination of spore # (or not)
+        if self.fitness_affects_spo_reproduction:
+            repro_script_p1 = REPRO_PTER_HETEROSPORE_P1.format(
+                spore_determination=FITNESS_AFFECTS_SPO_REPRODUCTION)
+
+        else: repro_script_p1 = REPRO_PTER_HETEROSPORE_P1.format(
+                spore_determination=CONSTANT_SPORES)
+
         self.model.repro(
             population="p0",
-            idx="s0",
-            scripts=REPRO_PTER_HETEROSPORE_P0,
-            comment="generates gametes from sporophytes"
+            scripts=repro_script_p0,
+            idx = "s0",
+            comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p1",
-            idx="s1",
-            scripts=REPRO_PTER_HETEROSPORE_P1,
+            scripts=repro_script_p1,
+            idx = "s1",
             comment="generates gametes from sporophytes"
         )
 
@@ -272,8 +328,8 @@ class PteridophyteVittaria(PteridophyteBase):
 
         early_script = (
             EARLY.format(
-                p0_fitnessScaling= P0_FITNESS_SCALE_DEFAULT,
-                p1_fitnessScaling= P1_FITNESS_SCALE_DEFAULT,
+                p0_survival_effects= P0_FITNESS_SCALE_DEFAULT,
+                p1_survival_effects= P1_FITNESS_SCALE_DEFAULT,
                 gametophyte_clones=GAM_CLONES,
                 gam_maternal_effect=GAM_MATERNAL_EFFECT_ON_P1,
                 sporophyte_clones=SPO_CLONES,
@@ -334,24 +390,24 @@ if __name__ == "__main__":
             sim_time=20,
         )
 
-        mod.reproduction.pteridophyte_homosporous(
+        mod.reproduction.pteridophyte_heterosporous(
             spo_pop_size=500,
             gam_pop_size=1_000,
             spo_spores_per=100,
             gam_archegonia_per=1,
-            gam_female_to_male_ratio=(1, 0),
+            gam_female_to_male_ratio=(1, 1),
             spo_clone_rate=0,
             spo_clones_per=0,
-            gam_clone_rate=0,
-            gam_clones_per=0,
+            #gam_clone_rate=0,
+            #gam_clones_per=0,
             spo_self_rate=0,
             spo_self_rate_per_egg=0,
-            gam_self_rate=0,
-            gam_self_rate_per_egg=0,
+            #gam_self_rate=0,
+            #gam_self_rate_per_egg=0,
             spo_random_death_chance=0,
             gam_random_death_chance=0,
             spo_maternal_effect=0.0,
-            gam_maternal_effect=0.0,
+            #gam_maternal_effect=0.0,
             gam_ceiling=3_000,
         )
 

--- a/shadie/reproduction/fernbase.py
+++ b/shadie/reproduction/fernbase.py
@@ -189,13 +189,13 @@ class PteridophyteHomosporous(PteridophyteBase):
         self.model.repro(
             population="p1",
             scripts=repro_script_p1,
-            idx = "s0",
+            idx = "s1",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p2",
             scripts=repro_script_p2,
-            idx = "s1",
+            idx = "s2",
             comment="generates gametes from sporophytes"
         )
 
@@ -279,13 +279,13 @@ class PteridophyteHeterosporous(PteridophyteBase):
         self.model.repro(
             population="p1",
             scripts=repro_script_p1,
-            idx = "s0",
+            idx = "s1",
             comment="generates sporophytes from gametes"
         )
         self.model.repro(
             population="p2",
             scripts=repro_script_p2,
-            idx = "s1",
+            idx = "s2",
             comment="generates gametes from sporophytes"
         )
 
@@ -347,13 +347,13 @@ class PteridophyteVittaria(PteridophyteBase):
         self.model.custom(scripts=DEFS_PTER_VITTARIA, comment="shadie DEFINITIONS")
         self.model.repro(
             population="p1",
-            idx="s0",
+            idx="s1",
             scripts=REPRO_PTER_VITTARIA_P1,
             comment="generates gametes from gametophytes"
         )
         self.model.repro(
             population="p2",
-            idx="s1",
+            idx="s2",
             scripts=REPRO_PTER_VITTARIA_P2,
             comment="generates spores from sporophytes"
         )

--- a/shadie/reproduction/scripts.py
+++ b/shadie/reproduction/scripts.py
@@ -76,7 +76,7 @@ EARLY = """
 
         // 3. Set up for next tick
         // fitness affects gametophyte survival
-        {p0_fitnessScaling}
+        {p0_survival_effects}
     }}
 
 
@@ -101,7 +101,7 @@ EARLY = """
 
         // 3. Set up for next tick
         // fitness is scaled relative to number of inds in p1
-        {p1_fitnessScaling}
+        {p1_survival_effects}
     }}
 """
 
@@ -118,16 +118,16 @@ SPO_CLONES = """
 """
 
 NO_SPO_CLONES = """
-        // remove parents
-        sim.killIndividuals(p1.individuals);
+    // remove parents
+    sim.killIndividuals(p1.individuals);
 """
 
 GAM_CLONES = """
-        // removes parents, except clones
-        non_clones = p0.individuals[p0.individuals.tag != 2];
-        sim.killIndividuals(non_clones);
-        // reset clone tags to regular tag
-        p0.individuals.tag = 1;
+    // removes parents, except clones
+    non_clones = p0.individuals[p0.individuals.tag != 2];
+    sim.killIndividuals(non_clones);
+    // reset clone tags to regular tag
+    p0.individuals.tag = 1;
 """
 
 NO_GAM_CLONES = """
@@ -146,6 +146,25 @@ P0_FITNESS_SCALE_DEFAULT = "p0.fitnessScaling = GAM_POP_SIZE / p0.individualCoun
 P1_FITNESS_SCALE_DEFAULT = "p1.fitnessScaling = SPO_POP_SIZE / p1.individualCount;"
 WF_FITNESS_SCALE = """inds = sim.subpopulations.individuals;
     p1.fitnessScaling = K / sum(inds.fitnessScaling);"""
+
+P0_RANDOM_SURVIVAL = """
+    num_to_kill = p0.individualCount - GAM_POP_SIZE
+    if num_to_kill > 0 {
+        random_inds = sample(p0.individuals, num_to_kill)
+        sim.killIndividuals(p0.individuals[random_inds]);           
+    }
+    //exact population is maintained
+    p0.fitnessScaling = GAM_POP_SIZE / p0.individualCount;
+"""
+P1_RANDOM_SURVIVAL = """
+    num_to_kill = p0.individualCount - SPO_POP_SIZE
+    if num_to_kill > 0 {
+        random_inds = sample(p1.individuals, num_to_kill)
+        sim.killIndividuals(p1.individuals[random_inds]);           
+    }
+    //exact population is maintained
+    p1.fitnessScaling = SPO_POP_SIZE / p1.individualCount;
+"""
 
 WF_REPRO_SOFT = """
     // parents are chosen proportional to fitness

--- a/shadie/reproduction/scripts.py
+++ b/shadie/reproduction/scripts.py
@@ -17,8 +17,8 @@ FIRST = """
         // reproduction(p1) will create SPOROPHYTES in p2.
 
         // set reproduction function to be used this generation
-        s0.active = 1; // GAM
-        s1.active = 0; // SPO
+        s1.active = 1; // GAM
+        s2.active = 0; // SPO
 
         // set mutation rate that will apply to the offspring
         sim.chromosome.setMutationRate(GAM_MUTATION_RATE);
@@ -28,8 +28,8 @@ FIRST = """
         // reproduction(p2) will produce GAMETOPHYTES into p1.
 
         // set reproduction function to be used this generation
-        s0.active = 0;  // GAM
-        s1.active = 1;  // SPO
+        s1.active = 0;  // GAM
+        s2.active = 1;  // SPO
 
         // set mutation rate that will apply to the offspring
         sim.chromosome.setMutationRate(SPO_MUTATION_RATE);

--- a/shadie/reproduction/scripts.py
+++ b/shadie/reproduction/scripts.py
@@ -14,25 +14,25 @@
 FIRST = """
 // alternate generations
     if (sim.cycle % 2 == 1) {
-        // reproduction(p0) will create SPOROPHYTES in p1.
+        // reproduction(p1) will create SPOROPHYTES in p2.
 
         // set reproduction function to be used this generation
-        s0.active = 1;
-        s1.active = 0;
+        s0.active = 1; // GAM
+        s1.active = 0; // SPO
 
         // set mutation rate that will apply to the offspring
-        sim.chromosome.setMutationRate(SPO_MUTATION_RATE);
+        sim.chromosome.setMutationRate(GAM_MUTATION_RATE);
     }
 
     else {
-        // reproduction(p1) will produce GAMETOPHYTES into p0.
+        // reproduction(p2) will produce GAMETOPHYTES into p1.
 
         // set reproduction function to be used this generation
         s0.active = 0;  // GAM
         s1.active = 1;  // SPO
 
         // set mutation rate that will apply to the offspring
-        sim.chromosome.setMutationRate(GAM_MUTATION_RATE);
+        sim.chromosome.setMutationRate(SPO_MUTATION_RATE);
     }
 """
 
@@ -47,59 +47,59 @@ FIRST = """
 # SPO_POP_SIZE
 # -------------------------
 EARLY = """
-// diploids (p1) just generated haploid gametophytes into p0
+// diploids (p2) just generated haploid gametophytes into p1
     if (community.tick % 2 == 0) {{
         
         // alternate generations.
             {sporophyte_clones}
 
-        // new p0s removed by three possible mechanisms:
+        // new p1s removed by three possible mechanisms:
         // 1. random chance of death.
         // 2. using fitness re-calculated to include maternal effect.
         // 3. individual goes on next tick (unless fitness kills it)
 
         // 1. make a mask for random death
         if (GAM_RANDOM_DEATH_CHANCE > 0) {{
-            random_death = (runif(p0.individualCount) < GAM_RANDOM_DEATH_CHANCE);
-            sim.killIndividuals(p0.individuals[random_death]);
+            random_death = (runif(p1.individualCount) < GAM_RANDOM_DEATH_CHANCE);
+            sim.killIndividuals(p1.individuals[random_death]);
         }}
 
         // random death also occurs to implement GAM_CEILING
-        if (p0.individualCount > GAM_CEILING) {{
+        if (p1.individualCount > GAM_CEILING) {{
             to_kill = GAM_CEILING - GAM_POP_SIZE;
-            death_chance = to_kill/p0.individualCount;
-            random_death = sample(c(F,T), p0.individualCount, T, c(1-death_chance, death_chance));
-            sim.killIndividuals(p0.individuals[random_death]);
+            death_chance = to_kill/p1.individualCount;
+            random_death = sample(c(F,T), p1.individualCount, T, c(1-death_chance, death_chance));
+            sim.killIndividuals(p1.individuals[random_death]);
             }}
 
        {spo_maternal_effect}
 
         // 3. Set up for next tick
         // fitness affects gametophyte survival
-        {p0_survival_effects}
+        {p1_survival_effects}
     }}
 
 
-    // odd generations = gametophytes (p0) just generated sporophytes
+    // odd generations = gametophytes (p1) just generated sporophytes
     else {{
         // alternate generations.
             {gametophyte_clones}
 
-        // remove new p1s by three possible mechanisms:
+        // remove new p2s by three possible mechanisms:
         // 1. random chance of death.
         // 2. using fitness re-calculated to include maternal effect.
         // 3. individual goes on next tick (unless fitness kills it)
 
         // 1. make a mask for random death
         if (SPO_RANDOM_DEATH_CHANCE > 0) {{
-            random_death = (runif(p1.individualCount) < GAM_RANDOM_DEATH_CHANCE);
-            sim.killIndividuals(p1.individuals[random_death]);
+            random_death = (runif(p2.individualCount) < GAM_RANDOM_DEATH_CHANCE);
+            sim.killIndividuals(p2.individuals[random_death]);
         }}
         {gam_maternal_effect}
 
         // 3. Set up for next tick
-        // fitness is scaled relative to number of inds in p1
-        {p1_survival_effects}
+        // fitness is scaled relative to number of inds in p2
+        {p2_survival_effects}
     }}
 """
 
@@ -109,28 +109,28 @@ EARLY = """
 
 SPO_CLONES = """
     // remove parents, except for clones
-    non_clones = p1.individuals[p1.individuals.tag != 4];
+    non_clones = p2.individuals[p2.individuals.tag != 4];
     sim.killIndividuals(non_clones);
     // reset clone tags to regular tag
-    p1.individuals.tag = 3;
+    p2.individuals.tag = 3;
 """
 
 NO_SPO_CLONES = """
     // remove parents
-    sim.killIndividuals(p1.individuals);
+    sim.killIndividuals(p2.individuals);
 """
 
 GAM_CLONES = """
     // removes parents, except clones
-    non_clones = p0.individuals[p0.individuals.tag != 2];
+    non_clones = p1.individuals[p1.individuals.tag != 2];
     sim.killIndividuals(non_clones);
     // reset clone tags to regular tag
-    p0.individuals.tag = 1;
+    p1.individuals.tag = 1;
 """
 
 NO_GAM_CLONES = """
     // remove parents
-    sim.killIndividuals(p0.individuals);
+    sim.killIndividuals(p1.individuals);
 """
 
 ###############################################################
@@ -140,28 +140,28 @@ NO_GAM_CLONES = """
 # GAM_POP_SIZE
 # SPO_POP_SIZE
 # ----------------------
-P0_FITNESS_SCALE_DEFAULT = "p0.fitnessScaling = GAM_POP_SIZE / p0.individualCount;"
-P1_FITNESS_SCALE_DEFAULT = "p1.fitnessScaling = SPO_POP_SIZE / p1.individualCount;"
+P1_FITNESS_SCALE_DEFAULT = "p1.fitnessScaling = GAM_POP_SIZE / p1.individualCount;"
+P2_FITNESS_SCALE_DEFAULT = "p2.fitnessScaling = SPO_POP_SIZE / p2.individualCount;"
 WF_FITNESS_SCALE = """inds = sim.subpopulations.individuals;
-    p1.fitnessScaling = K / sum(inds.fitnessScaling);"""
+    p2.fitnessScaling = K / sum(inds.fitnessScaling);"""
 
-P0_RANDOM_SURVIVAL = """
-    num_to_kill = p0.individualCount - GAM_POP_SIZE;
-    if (num_to_kill > 0) {
-        random_inds = sample(p0.individuals, num_to_kill);
-        sim.killIndividuals(p0.individuals[random_inds.index]);           
-    }
-    //exact population is maintained
-    p0.fitnessScaling = GAM_POP_SIZE / p0.individualCount;
-"""
 P1_RANDOM_SURVIVAL = """
-    num_to_kill = p1.individualCount - SPO_POP_SIZE;
+    num_to_kill = p1.individualCount - GAM_POP_SIZE;
     if (num_to_kill > 0) {
         random_inds = sample(p1.individuals, num_to_kill);
         sim.killIndividuals(p1.individuals[random_inds.index]);           
     }
     //exact population is maintained
-    p1.fitnessScaling = SPO_POP_SIZE / p1.individualCount;
+    p1.fitnessScaling = GAM_POP_SIZE / p1.individualCount;
+"""
+P2_RANDOM_SURVIVAL = """
+    num_to_kill = p2.individualCount - SPO_POP_SIZE;
+    if (num_to_kill > 0) {
+        random_inds = sample(p2.individuals, num_to_kill);
+        sim.killIndividuals(p2.individuals[random_inds.index]);           
+    }
+    //exact population is maintained
+    p2.fitnessScaling = SPO_POP_SIZE / p2.individualCount;
 """
 
 # -----------------------
@@ -169,8 +169,8 @@ P1_RANDOM_SURVIVAL = """
 
 FITNESS_AFFECTS_SPO_REPRODUCTION = """
 // fitness-based determination of how many spores are created by this ind
-    ind_fitness = p1.cachedFitness(ind.index);
-    max_fitness = max(p1.cachedFitness(NULL));
+    ind_fitness = p2.cachedFitness(ind.index);
+    max_fitness = max(p2.cachedFitness(NULL));
     ind_fitness_scaled = ind_fitness/max_fitness;
 
     spores = rbinom(1, SPO_SPORES_PER, ind_fitness_scaled);
@@ -180,7 +180,7 @@ CONSTANT_SPORES = "spores = SPO_SPORES_PER;"
 
 FITNESS_AFFECTS_GAM_MATING = """
 // fitness-based determination of sperm sampling
-    sperm_fitness_vector = p0.cachedFitness(outcross_sperms.index);
+    sperm_fitness_vector = p1.cachedFitness(outcross_sperms.index);
     sperm = sample(outcross_sperms, 1, weights = sperm_fitness_vector);
 """
 
@@ -188,23 +188,23 @@ RANDOM_MATING = "sperm = sample(outcross_sperms, 1);"
 
 WF_REPRO_SOFT = """
     // parents are chosen proportional to fitness
-    inds = p1.individuals;
-    fitness = p1.cachedFitness(NULL);
+    inds = p2.individuals;
+    fitness = p2.cachedFitness(NULL);
     parents1 = sample(inds, K, replace=T, weights=fitness);
     parents2 = sample(inds, K, replace=T, weights=fitness);
     for (i in seqLen(K))
-        p1.addCrossed(parents1[i], parents2[i]);
+        p2.addCrossed(parents1[i], parents2[i]);
     self.active = 0;
 """
 
 WF_REPRO_HARD = """
     // parents are chosen randomly (irrespective of fitness)
-    inds = p1.individuals;
-    fitness = p1.cachedFitness(NULL);
-    parents1 = p1.sampleIndividuals(K, replace=T);
-    parents2 = p1.sampleIndividuals(K, replace=T);
+    inds = p2.individuals;
+    fitness = p2.cachedFitness(NULL);
+    parents1 = p2.sampleIndividuals(K, replace=T);
+    parents2 = p2.sampleIndividuals(K, replace=T);
     for (i in seqLen(K))
-        p1.addCrossed(parents1[i], parents2[i]);
+        p2.addCrossed(parents1[i], parents2[i]);
     self.active = 0;
 """
 
@@ -217,16 +217,37 @@ DEACTIVATE = "{idx}.active = 0;"
 
 #################################################################
 # gam_maternal_effect
-GAM_MATERNAL_EFFECT_ON_P1 = """
+GAM_MATERNAL_EFFECT_ON_P2 = """
     // 2. maternal effect re-calculation
     if (GAM_MATERNAL_EFFECT > 0) {
         // temp fitness scaling
-        scale = SPO_POP_SIZE / p1.individualCount;
+        scale = SPO_POP_SIZE / p2.individualCount;
 
         // calculations
-        maternal_fitnesses = GAM_MATERNAL_EFFECT*p1.individuals.getValue("maternal_fitness");
-        child_fitnesses = (1 - GAM_MATERNAL_EFFECT)*p1.cachedFitness(NULL);
+        maternal_fitnesses = GAM_MATERNAL_EFFECT*p2.individuals.getValue("maternal_fitness");
+        child_fitnesses = (1 - GAM_MATERNAL_EFFECT)*p2.cachedFitness(NULL);
         corrected_fitnesses = scale*(maternal_fitnesses + child_fitnesses);
+
+        // remove inds based on maternal effects
+        to_kill = (runif(p2.individualCount) > corrected_fitnesses);
+        sim.killIndividuals(p2.individuals[to_kill]);
+    }
+"""
+
+NO_GAM_MATERNAL_EFFECT = """
+    // 2. No gametophyte maternal effect on p2
+"""
+
+# spo_maternal_effect
+SPO_MATERNAL_EFFECT_ON_P1 = """
+    // 2. maternal effect re-calculation
+    if (SPO_MATERNAL_EFFECT > 0) {
+        // temp fitness scaling
+        scale = SPO_POP_SIZE / p2.individualCount;
+        // calculations
+        maternal_fitnesses = SPO_MATERNAL_EFFECT*p1.individuals.getValue("maternal_fitness");
+        child_fitnesses = (1 - SPO_MATERNAL_EFFECT)*p1.cachedFitness(NULL);
+        corrected_fitnesses = scale * (maternal_fitnesses + child_fitnesses);
 
         // remove inds based on maternal effects
         to_kill = (runif(p1.individualCount) > corrected_fitnesses);
@@ -234,42 +255,21 @@ GAM_MATERNAL_EFFECT_ON_P1 = """
     }
 """
 
-NO_GAM_MATERNAL_EFFECT = """
-    // 2. No gametophyte maternal effect on P1
-"""
-
-# spo_maternal_effect
-SPO_MATERNAL_EFFECT_ON_P0 = """
-    // 2. maternal effect re-calculation
-    if (SPO_MATERNAL_EFFECT > 0) {
-        // temp fitness scaling
-        scale = SPO_POP_SIZE / p1.individualCount;
-        // calculations
-        maternal_fitnesses = SPO_MATERNAL_EFFECT*p0.individuals.getValue("maternal_fitness");
-        child_fitnesses = (1 - SPO_MATERNAL_EFFECT)*p0.cachedFitness(NULL);
-        corrected_fitnesses = scale * (maternal_fitnesses + child_fitnesses);
-
-        // remove inds based on maternal effects
-        to_kill = (runif(p0.individualCount) > corrected_fitnesses);
-        sim.killIndividuals(p0.individuals[to_kill]);
-    }
-"""
-
 NO_SPO_MATERNAL_EFFECT = """
-        // 2. No sporophyte maternal effect on P0
+        // 2. No sporophyte maternal effect on p1
 """
 
 ##################################################################
 # note relFitness was replaced by `effect` in SLiM 4.0
 HAP_MUT_FITNESS = """
-    if (individual.subpopulation == p1)
+    if (individual.subpopulation == p2)
         return 1.0;
     else
         return effect;
 """
 
 DIP_MUT_FITNESS = """
-    if (individual.subpopulation == p0)
+    if (individual.subpopulation == p1)
         return 1.0;
     else
         return effect;
@@ -295,9 +295,9 @@ function (void)report(s$ title) {
 
     cat(format('gen=%i, ', community.tick));
     cat(format('ngenomes=%i, ', sim.subpopulations.genomesNonNull.size())); // BCH
-    cat(format('(p1=%i, ', 2 * p1.individuals.size()));
-    cat(format('p0=%i, ', sum(p0.individuals.tag != 1)));
-    cat(format('p0 clone=%i)\n', sum(p0.individuals.tag == 1)));
+    cat(format('(p2=%i, ', 2 * p2.individuals.size()));
+    cat(format('p1=%i, ', sum(p1.individuals.tag != 1)));
+    cat(format('p1 clone=%i)\n', sum(p1.individuals.tag == 1)));
     cat("\n---------------------- fixed=" + sim.substitutions.size() + "\n\n");
 
     }

--- a/shadie/reproduction/specialWF_scripts.py
+++ b/shadie/reproduction/specialWF_scripts.py
@@ -11,10 +11,10 @@ string substitution.
 # -------------------------
 REPRO_WF = """
     // parents are chosen proportional to fitness
-    fitness = p1.cachedFitness(NULL);
-    parent = sample(p1.individuals, K, replace=T, weights=fitness);
+    fitness = p2.cachedFitness(NULL);
+    parent = sample(p2.individuals, K, replace=T, weights=fitness);
     for (i in seqLen(K))
-        p1.addRecombinant(parent.genome1[i], NULL, NULL, NULL, NULL, NULL);
+        p2.addRecombinant(parent.genome1[i], NULL, NULL, NULL, NULL, NULL);
 
     self.active = 0;
 """
@@ -26,12 +26,12 @@ REPRO_HAPLOID_WF = """
     // parents are chosen randomly. Two haploid genomes
     // come together and immediately produce a haploid child with recombination
 
-    fitness = p1.cachedFitness(NULL);
-    parent1 = sample(p1.individuals, K, replace=T);
-    parent2 = sample(p1.individuals, K, replace=T);
+    fitness = p2.cachedFitness(NULL);
+    parent1 = sample(p2.individuals, K, replace=T);
+    parent2 = sample(p2.individuals, K, replace=T);
     for (i in seqLen(K)){
         breaks = sim.chromosome.drawBreakpoints(parent1[i]);
-        p1.addRecombinant(parent1.genome1[i], parent2.genome1[i], breaks, NULL, NULL, NULL);
+        p2.addRecombinant(parent1.genome1[i], parent2.genome1[i], breaks, NULL, NULL, NULL);
     }
 
     self.active = 0;
@@ -41,12 +41,12 @@ REPRO_HAPLOID_SOFT_WF = """
     // parents are chosen proportional to fitness. Two haploid genomes
     // come together and immediately produce a haploid child with recombination
 
-    fitness = p1.cachedFitness(NULL);
-    parent1 = sample(p1.individuals, K, replace=T, weights=fitness);
-    parent2 = sample(p1.individuals, K, replace=T, weights=fitness);
+    fitness = p2.cachedFitness(NULL);
+    parent1 = sample(p2.individuals, K, replace=T, weights=fitness);
+    parent2 = sample(p2.individuals, K, replace=T, weights=fitness);
     for (i in seqLen(K)){
         breaks = sim.chromosome.drawBreakpoints(parent1[i]);
-        p1.addRecombinant(parent1.genome1[i], parent2.genome1[i], breaks, NULL, NULL, NULL);
+        p2.addRecombinant(parent1.genome1[i], parent2.genome1[i], breaks, NULL, NULL, NULL);
     }
 
     self.active = 0;
@@ -55,11 +55,11 @@ REPRO_HAPLOID_SOFT_WF = """
 REPRO_CLONAL_WF = """
     // parents are chosen randomly, produce one offpsring each time.
 
-    fitness = p1.cachedFitness(NULL);
-    parent1 = sample(p1.individuals, K, replace=T);
+    fitness = p2.cachedFitness(NULL);
+    parent1 = sample(p2.individuals, K, replace=T);
 
     for (i in seqLen(K)){
-        p1.addRecombinant(parent1.genome1[i], NULL, NULL, NULL, NULL, NULL);
+        p2.addRecombinant(parent1.genome1[i], NULL, NULL, NULL, NULL, NULL);
     }
 
     self.active = 0;
@@ -68,11 +68,11 @@ REPRO_CLONAL_WF = """
 REPRO_CLONAL_SOFT_WF = """
     // parents are chosen proportional to fitness, produce one offpsring each time.
 
-    fitness = p1.cachedFitness(NULL);
-    parent1 = sample(p1.individuals, K, replace=T, weights=fitness);
+    fitness = p2.cachedFitness(NULL);
+    parent1 = sample(p2.individuals, K, replace=T, weights=fitness);
 
     for (i in seqLen(K)){
-        p1.addRecombinant(parent1.genome1[i], NULL, NULL, NULL, NULL, NULL);
+        p2.addRecombinant(parent1.genome1[i], NULL, NULL, NULL, NULL, NULL);
     }
 
     self.active = 0;
@@ -81,24 +81,24 @@ REPRO_CLONAL_SOFT_WF = """
 # PARAMETERS
 # GAM_POP_SIZE
 # -------------------------
-REPRO_ALTGEN_P1 = """
+REPRO_ALTGEN_P2 = """
     // parents are chosen randomly
-    fitness = p1.cachedFitness(NULL);
-    parents = sample(p1.individuals, GAM_POP_SIZE, replace=T);
+    fitness = p2.cachedFitness(NULL);
+    parents = sample(p2.individuals, GAM_POP_SIZE, replace=T);
     for (i in seqLen(GAM_POP_SIZE)){
         breaks = sim.chromosome.drawBreakpoints(parents[i]);
-        p0.addRecombinant(parents.genome1[i], parents.genome2[i], breaks, NULL, NULL, NULL);
+        p1.addRecombinant(parents.genome1[i], parents.genome2[i], breaks, NULL, NULL, NULL);
     }
     self.active = 0;
 """
 
-REPRO_ALTGEN_SOFT_P1 = """
+REPRO_ALTGEN_SOFT_P2 = """
     // parents are chosen proportional to fitness
-    fitness = p1.cachedFitness(NULL);
-    parents = sample(p1.individuals, GAM_POP_SIZE, replace=T, weights=fitness);
+    fitness = p2.cachedFitness(NULL);
+    parents = sample(p2.individuals, GAM_POP_SIZE, replace=T, weights=fitness);
     for (i in seqLen(GAM_POP_SIZE)){
         breaks = sim.chromosome.drawBreakpoints(parents[i]);
-        p0.addRecombinant(parents.genome1[i], parents.genome2[i], breaks, NULL, NULL, NULL);
+        p1.addRecombinant(parents.genome1[i], parents.genome2[i], breaks, NULL, NULL, NULL);
     }
     self.active = 0;
 """
@@ -106,37 +106,37 @@ REPRO_ALTGEN_SOFT_P1 = """
 # PARAMETERS
 # SPO_POP_SIZE
 # -------------------------
-REPRO_ALTGEN_P0 = """
+REPRO_ALTGEN_P1 = """
     // parents are chosen randomly
-    fitness = p0.cachedFitness(NULL);
-    parents1 = sample(p0.individuals, SPO_POP_SIZE, replace=T);
-    parents2 = sample(p0.individuals, SPO_POP_SIZE, replace=T);
+    fitness = p1.cachedFitness(NULL);
+    parents1 = sample(p1.individuals, SPO_POP_SIZE, replace=T);
+    parents2 = sample(p1.individuals, SPO_POP_SIZE, replace=T);
     for (i in seqLen(SPO_POP_SIZE))
-        p1.addRecombinant(parents1.genome1[i], NULL, NULL, parents2.genome1[i], NULL, NULL);
+        p2.addRecombinant(parents1.genome1[i], NULL, NULL, parents2.genome1[i], NULL, NULL);
     self.active = 0;
 """
 
-REPRO_ALTGEN_SOFT_P0 = """
+REPRO_ALTGEN_SOFT_P1 = """
     // parents are chosen proportional to fitness
-    fitness = p0.cachedFitness(NULL);
-    parents1 = sample(p0.individuals, SPO_POP_SIZE, replace=T, weights=fitness);
-    parents2 = sample(p0.individuals, SPO_POP_SIZE, replace=T, weights=fitness);
+    fitness = p1.cachedFitness(NULL);
+    parents1 = sample(p1.individuals, SPO_POP_SIZE, replace=T, weights=fitness);
+    parents2 = sample(p1.individuals, SPO_POP_SIZE, replace=T, weights=fitness);
     for (i in seqLen(SPO_POP_SIZE))
-        p1.addRecombinant(parents1.genome1[i], NULL, NULL, parents2.genome1[i], NULL, NULL);
+        p2.addRecombinant(parents1.genome1[i], NULL, NULL, parents2.genome1[i], NULL, NULL);
     self.active = 0;
 """
 
 # ------------------
 WF_ALTGEN_EARLY = """
-    // diploids (p1) just generated haploid into p0
+    // diploids (p2) just generated haploid into p1
     if (community.tick % 2 == 0) {
         // fitness affects haploid survival
-        p0.fitnessScaling = GAM_POP_SIZE / p0.individualCount;
+        p1.fitnessScaling = GAM_POP_SIZE / p1.individualCount;
     }
-    // haploids (p0) just generated diploids into p1
+    // haploids (p1) just generated diploids into p2
     else {
         //fitness affects diploid survival
-        p1.fitnessScaling = SPO_POP_SIZE / p1.individualCount;
+        p2.fitnessScaling = SPO_POP_SIZE / p2.individualCount;
     }
 """
 

--- a/shadie/reproduction/vittaria_scripts.py
+++ b/shadie/reproduction/vittaria_scripts.py
@@ -6,8 +6,8 @@ Pteridophyte specific SLIM script snippets used for string substitution.
 
 DEFS_PTER_VITTARIA = """
 // model: homosporous pteridophyte
-// p0 = haploid population
-// p1 = diploid population
+// p1 = haploid population
+// p2 = diploid population
 // 1 = gametophyte (1N) tag
 // 2 = gametophyte clones (1N) tag
 // 3 = sporophyte (2N) tag
@@ -28,12 +28,12 @@ DEFS_PTER_VITTARIA = """
 # TAGS
 # L0, 2, 3
 #-----------------------------------------------------------------------
-REPRO_PTER_VITTARIA_P0 = """
-	// clonal individual get added to the p0 pool for next round.
+REPRO_PTER_VITTARIA_P1 = """
+	// clonal individual get added to the p1 pool for next round.
 	// NOTE: this doesn't allow clones to reproduce this round.
 	if (runif(1) < GAM_CLONE_RATE) {
 		for (i in 1:GAM_CLONES_PER) {
-			child = p0.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL, parent1 = individual); //only 1 parent recorded
+			child = p1.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL, parent1 = individual); //only 1 parent recorded
 			child.tag = 2; //marked as clone
 			child.tagL0 = individual.tagL0; //inherits parent sex
 			//gametophyte maternal effect not applicable for clones = neutral
@@ -54,7 +54,7 @@ REPRO_PTER_VITTARIA_P0 = """
 				// get all males that could fertilize an egg of this hermaphrodite
 				//In homosporous ferns, most gametophytes are hermaphroditic or male, 
 				//so "males" includes all the hermaphrodites as well as male gametophytes
-				males = p0.individuals;
+				males = p1.individuals;
 				
 				// if selfing is possible then get all sibling males
 				if (SPO_SELF_RATE_PER_EGG > 0)
@@ -74,7 +74,7 @@ REPRO_PTER_VITTARIA_P0 = """
 					
 					// intra-gametophytic selfed
 					if (mode == 1) {
-						child = p1.addRecombinant(individual.genome1, NULL, NULL, individual.genome1, NULL, NULL, parent1 = individual);
+						child = p2.addRecombinant(individual.genome1, NULL, NULL, individual.genome1, NULL, NULL, parent1 = individual);
 						child.tag = 3; //sporophyte tag
 						//gametophyte maternal effect on new sporophyte
 						if (GAM_MATERNAL_EFFECT > 0)
@@ -86,7 +86,7 @@ REPRO_PTER_VITTARIA_P0 = """
 					else if (mode == 2) {
 						if (siblings.size() > 0) {
 							sibling = sample(siblings, 1);
-							child = p1.addRecombinant(individual.genome1, NULL, NULL, sibling.genome1, NULL, NULL, parent1 = individual);
+							child = p2.addRecombinant(individual.genome1, NULL, NULL, sibling.genome1, NULL, NULL, parent1 = individual);
 							child.tag = 3; //sporophyte tag
 							//gametophyte maternal effect on new sporophyte
 							if (GAM_MATERNAL_EFFECT > 0)
@@ -94,7 +94,7 @@ REPRO_PTER_VITTARIA_P0 = """
 						}
 					}
 					
-					// outcrossing individual samples any other p0, and checks that it is outcrossing
+					// outcrossing individual samples any other p1, and checks that it is outcrossing
 					// only occurs if a non-sib gametophyte is still alive.
 					else {
 						// try at most 10 times to find a non-sib sperm, then skip.
@@ -105,7 +105,7 @@ REPRO_PTER_VITTARIA_P0 = """
 								//resulting in chromosomes composed of any of the 4 parental genomes
 								breaks1 = sim.chromosome.drawBreakpoints(individual);
         						breaks2 = sim.chromosome.drawBreakpoints(individual);
-								child = p1.addRecombinant(individual.genome1, individual.genome2, breaks1, sperm.genome1, sperm.genome2, breaks2, parent1 = individual, parent2=sperm);
+								child = p2.addRecombinant(individual.genome1, individual.genome2, breaks1, sperm.genome1, sperm.genome2, breaks2, parent1 = individual, parent2=sperm);
 								child.tag = 3; //sporophyte tag
 								//gametophyte maternal effect on new sporophyte
 								if (GAM_MATERNAL_EFFECT > 0)
@@ -131,15 +131,15 @@ REPRO_PTER_VITTARIA_P0 = """
 # TAGS
 # L0, 1, 4
 #-----------------------------------------------------------------------
-REPRO_PTER_VITTARIA_P1 = """
+REPRO_PTER_VITTARIA_P2 = """
 	ind = individual;
     
-    // clonal individual get added to the p0 pool for next round.
+    // clonal individual get added to the p1 pool for next round.
     // NOTE: this doesn't allow clones to reproduce this round.
     
     if (runif(1) < SPO_CLONE_RATE) {
         for (i in 1:SPO_CLONES_PER) {
-            child = p1.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL, parent1 = individual, parent2 = individual);
+            child = p2.addRecombinant(individual.genome1, NULL, NULL, individual.genome2, NULL, NULL, parent1 = individual, parent2 = individual);
             child.tag = 4; // sporophyte clone
             //sporophyte maternal effect not applicable for clones = neutral
             if (SPO_MATERNAL_EFFECT > 0)
@@ -148,8 +148,8 @@ REPRO_PTER_VITTARIA_P1 = """
     }
     
     // fitness-based determination of how many spores are created by this ind
-    ind_fitness = p1.cachedFitness(ind.index);
-    max_fitness = max(p1.cachedFitness(NULL));
+    ind_fitness = p2.cachedFitness(ind.index);
+    max_fitness = max(p2.cachedFitness(NULL));
     ind_fitness_scaled = ind_fitness/max_fitness; 
     
     spore_vector = sample(c(0,1), SPO_SPORES_PER, replace = T, weights = c((1-ind_fitness_scaled), ind_fitness_scaled));
@@ -165,10 +165,10 @@ REPRO_PTER_VITTARIA_P1 = """
         // create four meiotic products. If later two of these mate with each other
         // it is an example of sporophytic selfing. Because we need to be able to match
         // sibling gametes at that time we tag them now with their sporophyte parent's index. 
-        child1 = p0.addRecombinant(ind.genome1, ind.genome2, breaks1, ind.genome1, ind.genome2, breaks2, parent1 = ind);
-        child2 = p0.addRecombinant(ind.genome2, ind.genome1, breaks1, ind.genome2, ind.genome1, breaks2, parent1 = ind);
-        child3 = p0.addRecombinant(ind.genome1, ind.genome2, breaks3, ind.genome1, ind.genome2, breaks4, parent1 = ind);
-        child4 = p0.addRecombinant(ind.genome2, ind.genome1, breaks3, ind.genome2, ind.genome1, breaks4, parent1 = ind);
+        child1 = p1.addRecombinant(ind.genome1, ind.genome2, breaks1, ind.genome1, ind.genome2, breaks2, parent1 = ind);
+        child2 = p1.addRecombinant(ind.genome2, ind.genome1, breaks1, ind.genome2, ind.genome1, breaks2, parent1 = ind);
+        child3 = p1.addRecombinant(ind.genome1, ind.genome2, breaks3, ind.genome1, ind.genome2, breaks4, parent1 = ind);
+        child4 = p1.addRecombinant(ind.genome2, ind.genome1, breaks3, ind.genome2, ind.genome1, breaks4, parent1 = ind);
         children = c(child1, child2, child3, child4);
         children.tag = 1; //gametophyte tag
         children.tagL0 = ifelse(runif(1) < GAM_FEMALE_TO_MALE_RATIO, T, F);

--- a/shadie/reproduction/wfspecial.py
+++ b/shadie/reproduction/wfspecial.py
@@ -43,7 +43,6 @@ from shadie.reproduction.specialWF_scripts import (
     WF_ALTGEN_EARLY,
 )
 
-
 @dataclass
 class HaploidWF(ReproductionBase):
     """Reproduction mode based on Wright-Fisher model with clonal
@@ -51,7 +50,9 @@ class HaploidWF(ReproductionBase):
     pop_size: int  # number of haploid individuals
     selection: str = "none"
     _gens_per_lifecycle: int = 1
-    sexes: bool = False  # not yet used?
+    separate_sexes: bool = False
+    fitness_affects_survival: bool = True
+    fitness_affects_reproduction: bool = False
 
     def run(self):
         """Updates self.model.map with new component scripts for running
@@ -81,22 +82,7 @@ class HaploidWF(ReproductionBase):
 
     def _add_mode_scripts(self):
         """fitness and mating of diploid population."""
-
-        if self.selection == "none":
-            self.model.repro(
-                population="p1",
-                scripts= REPRO_HAPLOID_WF,
-                comment="haploid random mating; mating success weighted by fitness."
-            )
-
-        elif self.selection == "soft":
-            self.model.repro(
-                population="p1",
-                scripts= REPRO_HAPLOID_SOFT_WF,
-                comment="haploid random mating; mating success weighted by fitness."
-            )
-
-        elif self.selection == "hard":
+        if self.fitness_affects_survival:
             self.model.repro(
                 population="p1",
                 scripts= REPRO_HAPLOID_WF,
@@ -108,6 +94,20 @@ class HaploidWF(ReproductionBase):
                 scripts="p1.fitnessScaling = K / p1.individualCount",
                 comment="calculate relative fitness.",
             ) 
+
+        elif self.fitness_affects_reproduction:
+            self.model.repro(
+                population="p1",
+                scripts= REPRO_HAPLOID_SOFT_WF,
+                comment="haploid random mating; mating success weighted by fitness."
+            )
+
+        else:
+            self.model.repro(
+                population="p1",
+                scripts= REPRO_HAPLOID_WF,
+                comment="haploid random mating; mating success weighted by fitness."
+            )
 
     def _add_initialize_constants(self):
         """Add defineConstant calls to init for new variables."""
@@ -136,16 +136,15 @@ class HaploidWF(ReproductionBase):
             comment="non-overlapping generations",
         )
 
-
 @dataclass
 class ClonalHaploidWF(ReproductionBase):
     """Reproduction mode based on Wright-Fisher model with clonal
      haploid individuals."""
-    
     pop_size: int #number of haploid individuals
     selection:str = "none"
     _gens_per_lifecycle: int = 1
-    sexes: bool = False  # not yet used?
+    fitness_affects_survival: bool = True
+    fitness_affects_reproduction: bool = False
 
     def run(self):
         """
@@ -171,21 +170,14 @@ class ClonalHaploidWF(ReproductionBase):
 
     def _add_scripts(self):
         """fitness and mating of diploid population."""
-        if self.selection == "none":
-            self.model.repro(
-                population="p1",
-                scripts= REPRO_CLONAL_WF,
-                comment="haploid random mating; mating success weighted by fitness."
-            )
-
-        elif self.selection == "soft":
+        if self.fitness_affects_reproduction:
             self.model.repro(
                 population="p1",
                 scripts= REPRO_CLONAL_SOFT_WF,
                 comment="haploid random mating; mating success weighted by fitness."
             )
 
-        elif self.selection == "hard":
+        elif self.fitness_affects_survival:
             self.model.repro(
                 population="p1",
                 scripts= REPRO_CLONAL_WF,
@@ -197,6 +189,13 @@ class ClonalHaploidWF(ReproductionBase):
                 scripts="p1.fitnessScaling = K / p1.individualCount",
                 comment="calculate relative fitness.",
             ) 
+
+        else:
+            self.model.repro(
+                population="p1",
+                scripts= REPRO_CLONAL_WF,
+                comment="haploid random mating; mating success weighted by fitness."
+            )
 
     def _add_initialize_constants(self):
         """Add defineConstant calls to init for new variables."""
@@ -230,12 +229,13 @@ class ClonalHaploidWF(ReproductionBase):
 class AltGenWF(ReproductionBase):
     """Reproduction mode based on Wright-Fisher model with clonal
      haploid individuals."""
-    
     spo_pop_size: int # number of diploid individuals
     gam_pop_size: int # number of haploid individuals
     selection:str = "none"
     _gens_per_lifecycle: int = 2
-    sexes: bool = False  # not yet used?
+    fitness_affects_survival: bool =True
+    fitness_affects_reproduction: bool =False
+    separate_sexes: bool = False
 
     def run(self):
         """Updates self.model.map with new component scripts for running
@@ -264,22 +264,7 @@ class AltGenWF(ReproductionBase):
     def _add_scripts(self):
         """fitness and mating of diploid population."""
 
-        if self.selection == "none":
-
-            self.model.repro(
-                population="p1",
-                scripts= REPRO_ALTGEN_P1,
-                comment="clonal random mating; mating success weighted by fitness."
-            )
-
-            self.model.repro(
-                population="p0",
-                scripts= REPRO_ALTGEN_P0,
-                comment="clonal random mating; mating success weighted by fitness."
-            )
-
-        elif self.selection == "soft":
-
+        if self.fitness_affects_reproduction:
             self.model.repro(
                 population="p1",
                 scripts= REPRO_ALTGEN_SOFT_P1,
@@ -292,8 +277,7 @@ class AltGenWF(ReproductionBase):
                 comment="clonal random mating; mating success weighted by fitness."
             )
 
-        elif self.selection == "hard":
-
+        elif self.fitness_affects_survival:
             self.model.repro(
                 population="p1",
                 scripts= REPRO_ALTGEN_P1,
@@ -310,6 +294,19 @@ class AltGenWF(ReproductionBase):
                 time = None,
                 scripts=WF_ALTGEN_EARLY,
                 comment="Fitness scaling for hard selection"
+            )
+
+        else:
+            self.model.repro(
+                population="p1",
+                scripts= REPRO_ALTGEN_P1,
+                comment="clonal random mating; mating success weighted by fitness."
+            )
+
+            self.model.repro(
+                population="p0",
+                scripts= REPRO_ALTGEN_P0,
+                comment="clonal random mating; mating success weighted by fitness."
             )
 
     def _add_initialize_constants(self):
@@ -377,7 +374,7 @@ class AltGenWF(ReproductionBase):
 class Moran(WrightFisher):
     """Reproduction mode based on Wright-Fisher model."""
     pop_size: int
-    sexes: bool = False  # not yet used?
+    separate_sexes: bool = False
     _gens_per_lifecycle: int = 1
 
     def run(self):
@@ -429,7 +426,7 @@ if __name__ == "__main__":
 
     with shadie.Model() as mod:
         mod.initialize(chromosome=chrom, sim_time=50, file_out="/tmp/test.trees")
-        mod.reproduction.wright_fisher_haploid_clonal(
+        mod.reproduction.bryophyte_monoicous(
             pop_size=500,
         )
     print(mod.script)

--- a/shadie/reproduction/wfspecial.py
+++ b/shadie/reproduction/wfspecial.py
@@ -48,11 +48,10 @@ class HaploidWF(ReproductionBase):
     """Reproduction mode based on Wright-Fisher model with clonal
      haploid individuals."""
     pop_size: int  # number of haploid individuals
-    selection: str = "none"
-    _gens_per_lifecycle: int = 1
     separate_sexes: bool = False
     fitness_affects_survival: bool = True
     fitness_affects_reproduction: bool = False
+    _gens_per_lifecycle: int = 1
 
     def run(self):
         """Updates self.model.map with new component scripts for running
@@ -118,7 +117,8 @@ class HaploidWF(ReproductionBase):
             'gam_pop_size': self.pop_size,
             'spo_mutation_rate': self.model.metadata['mutation_rate'],
             'recombination_rate': self.model.metadata['recomb_rate'],
-            'selection': self.selection,
+            'fitness_affects_survival': self.fitness_affects_survival,
+            'fitness_affects_reproduction': self.fitness_affects_reproduction,
             'gens_per_lifecycle': self._gens_per_lifecycle,
         }
 
@@ -141,10 +141,9 @@ class ClonalHaploidWF(ReproductionBase):
     """Reproduction mode based on Wright-Fisher model with clonal
      haploid individuals."""
     pop_size: int #number of haploid individuals
-    selection:str = "none"
-    _gens_per_lifecycle: int = 1
     fitness_affects_survival: bool = True
     fitness_affects_reproduction: bool = False
+    _gens_per_lifecycle: int = 1
 
     def run(self):
         """
@@ -206,7 +205,8 @@ class ClonalHaploidWF(ReproductionBase):
             'gam_pop_size': self.pop_size,
             'spo_mutation_rate': self.model.metadata['mutation_rate'],
             'recombination_rate': self.model.metadata['recomb_rate'],
-            'selection': self.selection,
+            'fitness_affects_survival': self.fitness_affects_survival,
+            'fitness_affects_reproduction': self.fitness_affects_reproduction,
             'gens_per_lifecycle': self._gens_per_lifecycle,
         }
 
@@ -231,11 +231,10 @@ class AltGenWF(ReproductionBase):
      haploid individuals."""
     spo_pop_size: int # number of diploid individuals
     gam_pop_size: int # number of haploid individuals
-    selection:str = "none"
-    _gens_per_lifecycle: int = 2
     fitness_affects_survival: bool =True
     fitness_affects_reproduction: bool =False
     separate_sexes: bool = False
+    _gens_per_lifecycle: int = 2
 
     def run(self):
         """Updates self.model.map with new component scripts for running
@@ -317,7 +316,8 @@ class AltGenWF(ReproductionBase):
             'spo_pop_size': self.spo_pop_size,
             'gam_pop_size': self.gam_pop_size,
             'spo_mutation_rate': self.model.metadata['mutation_rate'],
-            'selection': self.selection,
+            'fitness_affects_survival': self.fitness_affects_survival,
+            'fitness_affects_reproduction': self.fitness_affects_reproduction,
             'recombination_rate': self.model.metadata['recomb_rate']
         }
 
@@ -375,6 +375,7 @@ class Moran(WrightFisher):
     """Reproduction mode based on Wright-Fisher model."""
     pop_size: int
     separate_sexes: bool = False
+    age_of_death: int = 10
     _gens_per_lifecycle: int = 1
 
     def run(self):
@@ -392,7 +393,14 @@ class Moran(WrightFisher):
         self._add_survival_script()
 
     def _add_survival_script(self):
-        pass
+        """Defines the late() callbacks for each gen.
+        This overrides the NonWrightFisher class function of same name.
+        """
+        self.model.survival(
+            population=None,
+            scripts=f"return (individual.age < {self.age_of_death});",
+            comment=f"Individuals will die at age {self.age_of_death}",
+        )
 
 
 if __name__ == "__main__":

--- a/shadie/reproduction/wfspecial.py
+++ b/shadie/reproduction/wfspecial.py
@@ -29,6 +29,7 @@ from shadie.reproduction.scripts import (
     HAP_MUT_FITNESS,
     DIP_MUT_FITNESS
 )
+
 from shadie.reproduction.specialWF_scripts import (
     REPRO_WF,
     REPRO_HAPLOID_WF,
@@ -231,8 +232,8 @@ class AltGenWF(ReproductionBase):
      haploid individuals."""
     spo_pop_size: int # number of diploid individuals
     gam_pop_size: int # number of haploid individuals
-    fitness_affects_survival: bool =True
-    fitness_affects_reproduction: bool =False
+    fitness_affects_survival: bool = True
+    fitness_affects_reproduction: bool = False
     separate_sexes: bool = False
     _gens_per_lifecycle: int = 2
 
@@ -433,9 +434,10 @@ if __name__ == "__main__":
     )
 
     with shadie.Model() as mod:
-        mod.initialize(chromosome=chrom, sim_time=50, file_out="/tmp/test.trees")
-        mod.reproduction.bryophyte_monoicous(
-            pop_size=500,
+        mod.initialize(chromosome=chrom, sim_time=100, file_out="/tmp/test.trees")
+        mod.reproduction.wright_fisher_altgen(
+            spo_pop_size=500,
+            gam_pop_size=500,
         )
     print(mod.script)
     # mod.write("/tmp/slim.slim")

--- a/shadie/reproduction/wfspecial.py
+++ b/shadie/reproduction/wfspecial.py
@@ -22,8 +22,8 @@ from dataclasses import dataclass, field
 from shadie.reproduction.base import ReproductionBase
 from shadie.reproduction.base import WrightFisher
 from shadie.reproduction.scripts import (
-    GAM_MATERNAL_EFFECT_ON_P1,
-    P0_FITNESS_SCALE_DEFAULT,
+    GAM_MATERNAL_EFFECT_ON_P2,
+    P1_FITNESS_SCALE_DEFAULT,
     # EARLY_WITH_GAM_K,
     EARLY,
     HAP_MUT_FITNESS,
@@ -36,10 +36,10 @@ from shadie.reproduction.specialWF_scripts import (
     REPRO_HAPLOID_SOFT_WF,
     REPRO_CLONAL_WF,
     REPRO_CLONAL_SOFT_WF,
+    REPRO_ALTGEN_P2,
+    REPRO_ALTGEN_SOFT_P2,
     REPRO_ALTGEN_P1,
     REPRO_ALTGEN_SOFT_P1,
-    REPRO_ALTGEN_P0,
-    REPRO_ALTGEN_SOFT_P0,
     OLD_SURV_WF,
     WF_ALTGEN_EARLY,
 )
@@ -76,7 +76,7 @@ class HaploidWF(ReproductionBase):
         else:
             self.model.first(
                 time=1,
-                scripts="sim.addSubpop('p1', K, haploid=T);",
+                scripts="sim.addSubpop('p2', K, haploid=T);",
                 comment="define starting haploid population.",
             )
 
@@ -84,27 +84,27 @@ class HaploidWF(ReproductionBase):
         """fitness and mating of diploid population."""
         if self.fitness_affects_survival:
             self.model.repro(
-                population="p1",
+                population="p2",
                 scripts= REPRO_HAPLOID_WF,
                 comment="haploid random mating; mating success weighted by fitness."
             )
 
             self.model.early(
                 time=None,
-                scripts="p1.fitnessScaling = K / p1.individualCount",
+                scripts="p2.fitnessScaling = K / p2.individualCount",
                 comment="calculate relative fitness.",
             ) 
 
         elif self.fitness_affects_reproduction:
             self.model.repro(
-                population="p1",
+                population="p2",
                 scripts= REPRO_HAPLOID_SOFT_WF,
                 comment="haploid random mating; mating success weighted by fitness."
             )
 
         else:
             self.model.repro(
-                population="p1",
+                population="p2",
                 scripts= REPRO_HAPLOID_WF,
                 comment="haploid random mating; mating success weighted by fitness."
             )
@@ -164,7 +164,7 @@ class ClonalHaploidWF(ReproductionBase):
         else:
             self.model.first(
                 time=1,
-                scripts="sim.addSubpop('p1', K, haploid=T);",
+                scripts="sim.addSubpop('p2', K, haploid=T);",
                 comment="define starting haploid population.",
             )
 
@@ -172,27 +172,27 @@ class ClonalHaploidWF(ReproductionBase):
         """fitness and mating of diploid population."""
         if self.fitness_affects_reproduction:
             self.model.repro(
-                population="p1",
+                population="p2",
                 scripts= REPRO_CLONAL_SOFT_WF,
                 comment="haploid random mating; mating success weighted by fitness."
             )
 
         elif self.fitness_affects_survival:
             self.model.repro(
-                population="p1",
+                population="p2",
                 scripts= REPRO_CLONAL_WF,
                 comment="haploid random mating; mating success weighted by fitness."
             )
 
             self.model.early(
                 time=None,
-                scripts="p1.fitnessScaling = K / p1.individualCount",
+                scripts="p2.fitnessScaling = K / p2.individualCount",
                 comment="calculate relative fitness.",
             ) 
 
         else:
             self.model.repro(
-                population="p1",
+                population="p2",
                 scripts= REPRO_CLONAL_WF,
                 comment="haploid random mating; mating success weighted by fitness."
             )
@@ -256,8 +256,8 @@ class AltGenWF(ReproductionBase):
         else:
             self.model.first(
                 time=1,
-                scripts=("sim.addSubpop('p1', SPO_POP_SIZE);\n"
-                		 "sim.addSubpop('p0', 0);"),
+                scripts=("sim.addSubpop('p2', SPO_POP_SIZE);\n"
+                		 "sim.addSubpop('p1', 0);"),
                 comment="define starting haploid population.",
             )
 
@@ -266,27 +266,27 @@ class AltGenWF(ReproductionBase):
 
         if self.fitness_affects_reproduction:
             self.model.repro(
+                population="p2",
+                scripts= REPRO_ALTGEN_SOFT_P2,
+                comment="clonal random mating; mating success weighted by fitness."
+            )
+
+            self.model.repro(
                 population="p1",
                 scripts= REPRO_ALTGEN_SOFT_P1,
                 comment="clonal random mating; mating success weighted by fitness."
             )
 
+        elif self.fitness_affects_survival:
             self.model.repro(
-                population="p0",
-                scripts= REPRO_ALTGEN_SOFT_P0,
+                population="p2",
+                scripts= REPRO_ALTGEN_P2,
                 comment="clonal random mating; mating success weighted by fitness."
             )
 
-        elif self.fitness_affects_survival:
             self.model.repro(
                 population="p1",
                 scripts= REPRO_ALTGEN_P1,
-                comment="clonal random mating; mating success weighted by fitness."
-            )
-
-            self.model.repro(
-                population="p0",
-                scripts= REPRO_ALTGEN_P0,
                 comment="clonal random mating; mating success weighted by fitness."
             )
 
@@ -298,14 +298,14 @@ class AltGenWF(ReproductionBase):
 
         else:
             self.model.repro(
-                population="p1",
-                scripts= REPRO_ALTGEN_P1,
+                population="p2",
+                scripts= REPRO_ALTGEN_P2,
                 comment="clonal random mating; mating success weighted by fitness."
             )
 
             self.model.repro(
-                population="p0",
-                scripts= REPRO_ALTGEN_P0,
+                population="p1",
+                scripts= REPRO_ALTGEN_P1,
                 comment="clonal random mating; mating success weighted by fitness."
             )
 


### PR DESCRIPTION
Update fixes selection to allow the option for survival and reproduction selection in both life stages for all models, which fixes a major bug that may affect simulation outcomes (when expectations are based on 1 generation = 2 SLiM cycles). 

Additional changes: 

- changed the syntax for population names in the Eidos model - instead of using p0 for gametophytes and p1 for sporophytes, we changed the notation to p1 for gametophytes (which are usually haploid, or 1N) and p2 for sporophytes (which are usually diploids, or 2N). We believe this is much more intuitive for the user. 
- angiosperm models now separate pollen and eggs into separate populations, which allows us to properly control population sizes. Otherwise, simulations with realistic parameters tend to gradually lose females until none are left (within ~20 gens or less). p0 is now used for pollen. 